### PR TITLE
fix: trigger io.eof event on immediate EOF

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -1642,7 +1642,12 @@ func (vm *VM) runStayLoop(stay *StayLoop) (value.Value, error) {
 		case event := <-stay.EventQueue:
 			// Execute the handler callback synchronously
 			if event.Handler.Status == value.HandlerActive {
-				result, err := vm.callValueSync(event.Handler.Callback, []value.Value{event.Value})
+				// EOF events don't pass a value to the callback (handler is () => ...)
+				var args []value.Value
+				if event.Handler.Source.Kind != value.EventSourceEOF {
+					args = []value.Value{event.Value}
+				}
+				result, err := vm.callValueSync(event.Handler.Callback, args)
 				if err != nil {
 					return value.Null(), err
 				}
@@ -2022,7 +2027,8 @@ func (vm *VM) initStdinSource() {
 					return
 				}
 			}
-			// EOF reached
+			// EOF reached - send null value before closing to trigger eof event handler
+			vm.eofSource.Channel <- value.Null()
 			close(vm.eofSource.Channel)
 		}()
 	})


### PR DESCRIPTION
## Summary

- Fix io.eof event not triggering when stdin receives immediate EOF (e.g., `< /dev/null`)
- Send null value to EOF channel before closing to ensure event handlers receive the event
- Don't pass arguments to EOF handlers since they expect `() => ...` per language spec

## Problem

When running a Calcium program with immediate EOF:
```bash
calcium program.ca < /dev/null
```

The program would hang indefinitely because:
1. `close(channel)` alone doesn't trigger the event handler
2. EOF handlers are defined as `() => ...` (no arguments), but the event system was passing a value

## Test plan

- [x] `echo "hello" | calcium test.ca` - stdin works correctly
- [x] `calcium test.ca < /dev/null` - EOF triggers immediately (previously hung)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)