### PR TITLE
docs: sync spec with implementation for string + and io functions

### DIFF
--- a/calcium-spec.md
+++ b/calcium-spec.md
@@ -476,30 +476,31 @@ items |> map(double);
 items |> map(triple);
 ```
 
-### Function Scope Constraints
+### Function Scope and Closures
 
-Functions can only reference their parameters. Capturing external variables (closures) is prohibited.
+Functions and lambdas can reference external variables (closures are supported).
 
 ```calcium
-// OK: Only references parameters
+// Reference parameters
 func add(a, b) = a + b;
 f = (x) => x * 2;
 
-// NG: References external variable
+// Capture external variable (closure)
 n = 2;
-f = (x) => x * n;   // Error: n is not a parameter
+f = (x) => x * n;   // OK: n is captured
+f(5);               // 10
+
+// Return a function that captures parameter
+func make_adder(x) = n => x + n;
+add5 = make_adder(5);
+add5(3);            // 8
 ```
 
-All state must be explicitly passed as arguments:
+Closures can be used with higher-order functions:
 
 ```calcium
-// NG: Capturing n via closure
 n = 2;
-[1, 2, 3] |> map(x => x * n);
-
-// OK: Pass required value as argument
-func multiply_by(n, x) = x * n;
-[1, 2, 3] |> map(x => multiply_by(2, x));
+[1, 2, 3] |> map(x => x * n);  // [2, 4, 6]
 ```
 
 ### Shadowing


### PR DESCRIPTION
## Summary

- `+` 演算子を数値のみから「数値と文字列」に変更（文字列の `+` は `concat()` の糖衣構文）
- 出力関数 `io.println` を主として記載、`io.say` はそのシノニム（同義語）と明記
- I/O関数のテーブル追加でわかりやすく整理

## 変更ファイル

- `calcium-spec.md`

## 関連Issue

Closes #5

## Test plan

- [ ] ドキュメント内容が実装と整合しているか確認
- [ ] 記載されたコード例が正しく動作するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)