### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to enable automated dependency updates
- Weekly updates for Go modules and GitHub Actions

## Test plan
- [ ] Dependabot starts creating PRs after merge

Closes #15