### PR TITLE
fix: add CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         if: matrix.go-version == '1.22'
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Summary
- codecov-action v4ではtoken必須
- `secrets.CODECOV_TOKEN` を使用するように修正

## Test plan
- [ ] CIが通ること
- [ ] Codecovにカバレッジがアップロードされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)