### PR TITLE
ci: add Go 1.23 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.21', '1.22', '1.23']
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.22'
+        if: matrix.go-version == '1.23'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- CIテストマトリクスにGo 1.23を追加
- Codecov uploadをGo 1.23で実行するよう変更

## Test plan

- [ ] CI passes on Go 1.21, 1.22, 1.23

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)