### PR TITLE
feat: add release workflow with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,71 @@
+# GoReleaser configuration for Calcium
+# https://goreleaser.com
+
+version: 2
+
+project_name: calcium
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: calcium
+    binary: calcium
+    main: ./cmd/calcium
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+  - id: bone
+    binary: bone
+    main: ./cmd/bone
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - id: calcium-archive
+    builds:
+      - calcium
+      - bone
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: ytnobody
+    name: calcium-lang
+  prerelease: auto
+  draft: false


### PR DESCRIPTION
## Summary
- GoReleaserによるリリースワークフローを追加
- `calcium` と `bone` の両バイナリをマルチプラットフォームでビルド
- バージョンタグ（`v*`）のプッシュで自動リリース

## 変更内容
- `.goreleaser.yml`: GoReleaser設定（Linux/macOS/Windows × amd64/arm64）
- `.github/workflows/release.yml`: タグプッシュトリガーのワークフロー

## 使い方
```bash
git tag v0.2.1
git push origin v0.2.1
```
→ 自動的にGitHub Releaseが作成され、ビルド済みバイナリがアップロードされます。

## Test plan
- [ ] CIが通ることを確認
- [ ] タグをプッシュしてリリースが作成されることを確認（オーナー確認後）

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)