### PR TITLE
chore: add golangci-lint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+# golangci-lint configuration for Calcium
+# https://golangci-lint.run/usage/configuration/
+
+run:
+  timeout: 5m
+  go: "1.21"
+
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+  disable:
+    # unused is disabled until core.math module is connected (see Issue tracking unused builtin functions)
+    - unused
+
+linters-settings:
+  errcheck:
+    # Ignore specific functions
+    exclude-functions:
+      - os.Chdir
+      - os.WriteFile
+      - os.Remove
+      - os.RemoveAll
+      - (io.Closer).Close
+      # Internal VM operations where errors are handled differently
+      # TODO: Review these for proper error handling in a future PR
+      - (*github.com/ytnobody/calcium-lang/pkg/vm.VM).push
+      - github.com/ytnobody/calcium-lang/pkg/vm.saveToCacheDir
+
+issues:
+  # Maximum issues count per linter
+  max-issues-per-linter: 50
+  # Maximum count of issues with same text
+  max-same-issues: 10
+
+  exclude-rules:
+    # Ignore errcheck in test files for common setup/teardown operations
+    - path: _test\.go
+      linters:
+        - errcheck

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1143,9 +1143,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 				parts := strings.Split(node.Path.RawURL, "/")
 				moduleName = parts[len(parts)-1]
 				// Remove -calcium suffix if present
-				if strings.HasSuffix(moduleName, "-calcium") {
-					moduleName = strings.TrimSuffix(moduleName, "-calcium")
-				}
+				moduleName = strings.TrimSuffix(moduleName, "-calcium")
 			} else {
 				// author/module format: "ytnobody/json"
 				modulePath = node.Path.Author + "/" + node.Path.Name

--- a/pkg/optimizer/cse.go
+++ b/pkg/optimizer/cse.go
@@ -143,6 +143,7 @@ func (o *CSEOptimizer) optimizeSubExprs(expr ast.Expression) ast.Expression {
 		left := o.optimizeExpr(e.Left)
 		right := o.optimizeExpr(e.Right)
 		// Check if left and right are identical pure expressions
+		//nolint:staticcheck // TODO: Implement CSE optimization with AST transformation
 		if o.isPureExpr(left) && o.exprEqual(left, right) {
 			// They're the same, but we can't easily introduce a let binding
 			// at this level without AST transformation support.

--- a/pkg/vm/stdlib.go
+++ b/pkg/vm/stdlib.go
@@ -384,7 +384,7 @@ func (vm *VM) LoadRemoteModule(author, name string) (*value.Module, error) {
 		}
 		// Save to global cache
 		globalDir := getModuleCachePath(author, name)
-		saveToCacheDir(globalDir, "mod.ca", content)
+		saveToCacheDir(globalDir, "mod.ca", content) //nolint:errcheck // TODO: Handle error properly
 		moduleDir = globalDir
 	}
 
@@ -446,7 +446,7 @@ func (vm *VM) LoadGitHubURLModule(url string) (*value.Module, error) {
 			return nil, fmt.Errorf("GitHub module not found: %s", url)
 		}
 		// Save to cache
-		saveToCacheDir(cacheDir, "mod.ca", content)
+		saveToCacheDir(cacheDir, "mod.ca", content) //nolint:errcheck // TODO: Handle error properly
 	}
 
 	// Compile and cache the module

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2250,7 +2250,8 @@ func builtinPush(args ...value.Value) value.Value {
 }
 
 func builtinRange(args ...value.Value) value.Value {
-	var start, end, step int64 = 0, 0, 1
+	var start, step int64 = 0, 1
+	var end int64
 	switch len(args) {
 	case 1:
 		if args[0].Type != value.TYPE_INT {


### PR DESCRIPTION
## Summary

- Add `.golangci.yml` configuration for the project
- Enable linters: errcheck, gosimple, govet, ineffassign, staticcheck
- Disable `unused` linter until core.math module is connected (tracked separately)
- Add golangci-lint step to CI workflow
- Fix minor lint warnings (gosimple, ineffassign)
- Add nolint comments for known issues to be addressed in future PRs

## Changes

| File | Change |
|------|--------|
| `.golangci.yml` | New linter configuration |
| `.github/workflows/ci.yml` | Add golangci-lint action |
| `pkg/compiler/compiler.go` | Fix gosimple: use strings.TrimSuffix directly |
| `pkg/vm/vm.go` | Fix ineffassign: remove unused initialization |
| `pkg/vm/stdlib.go` | Add nolint for errcheck (TODO for future) |
| `pkg/optimizer/cse.go` | Add nolint for staticcheck (TODO for future) |

## Test plan

- [ ] CI passes (lint, build, test)
- [ ] golangci-lint runs successfully in CI

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)