### PR TITLE
docs: add installation guide for GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo mv bone /usr/local/bin/
 
 ### Build from Source
 
-Requires Go 1.24 or later.
+Requires Go 1.22 or later.
 
 ```bash
 go build -o calcium ./cmd/calcium


### PR DESCRIPTION
## Summary
- README の Installation セクションに GitHub Releases からのダウンロード方法を追加
- 対応プラットフォーム（Linux/macOS/Windows × amd64/arm64）を明記
- bone セクションの重複するビルド手順を簡略化（Releases に含まれる旨を記載）

## Test plan
- [x] README.md の差分を確認
- [ ] リンク先（GitHub Releases）が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)