### PR TITLE
feat: add calcium-test module (TAP-compatible test framework)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,148 @@
+# calcium-test
+
+TAP-compatible test framework for the [Calcium](https://github.com/ytnobody/calcium-lang) programming language, inspired by Perl's [Test::More](https://metacpan.org/pod/Test::More).
+
+## Installation
+
+```
+bone add ytnobody/test
+```
+
+## Usage
+
+```calcium
+use test;
+
+ctx = test.new();
+ctx = test.plan(ctx, 3);
+ctx = test.is(ctx, "addition", 1 + 1, 2);
+ctx = test.ok(ctx, "truthy check", true);
+ctx = test.isnt(ctx, "not equal", 1, 2);
+test.done(ctx);
+```
+
+Output:
+
+```
+1..3
+ok 1 - addition
+ok 2 - truthy check
+ok 3 - not equal
+# Tests: 3
+# Passed: 3
+# Failed: 0
+```
+
+## API
+
+### Context Management
+
+#### `new()`
+
+Creates a fresh test context. All test functions take a context as the first argument and return an updated context.
+
+```calcium
+ctx = test.new();
+// => {total: 0, passed: 0, failed: 0, planned: 0}
+```
+
+#### `plan(ctx, n)`
+
+Declares the expected number of tests. Prints `1..N` in TAP format. If the actual test count doesn't match at `done()`, a diagnostic message is printed.
+
+```calcium
+ctx = test.plan(ctx, 5);
+// Output: 1..5
+```
+
+### Assertions
+
+All assertion functions print a TAP result line immediately and return the updated context.
+
+#### `ok(ctx, label, value)`
+
+Asserts that `value` is truthy (not `false`, `null`, `0`, or `""`).
+
+```calcium
+ctx = test.ok(ctx, "truthy check", true);
+// Output: ok 1 - truthy check
+```
+
+#### `is(ctx, label, actual, expected)`
+
+Asserts that `actual` equals `expected`.
+
+```calcium
+ctx = test.is(ctx, "addition", 1 + 1, 2);
+// Output: ok 1 - addition
+```
+
+On failure, diagnostic output shows the actual and expected values:
+
+```
+not ok 1 - addition
+#   got:      3
+#   expected: 2
+```
+
+#### `isnt(ctx, label, actual, expected)`
+
+Asserts that `actual` does not equal `expected`.
+
+```calcium
+ctx = test.isnt(ctx, "not equal", 1, 2);
+// Output: ok 1 - not equal
+```
+
+#### `pass(ctx, label)`
+
+Unconditionally records a passing test.
+
+```calcium
+ctx = test.pass(ctx, "always passes");
+// Output: ok 1 - always passes
+```
+
+#### `fail(ctx, label)`
+
+Unconditionally records a failing test.
+
+```calcium
+ctx = test.fail(ctx, "always fails");
+// Output: not ok 1 - always fails
+#   explicitly failed
+```
+
+### Summary
+
+#### `done(ctx)`
+
+Prints the test summary and checks the plan. Call this at the end of your test file.
+
+```calcium
+test.done(ctx);
+// Output:
+// # Tests: 5
+// # Passed: 4
+// # Failed: 1
+// # Looks like you planned 5 tests but ran 4
+```
+
+## Design Notes
+
+Calcium is a functional language with no mutable state. The test module uses a **context threading** pattern: each assertion function takes a context hash as its first argument and returns an updated context. This allows tracking test counts across assertions without mutation.
+
+Each assertion is a side-effectful function (`func!`) that prints TAP output immediately while returning the updated context for the next assertion.
+
+## TAP Compatibility
+
+Output follows the [Test Anything Protocol](https://testanything.org/):
+
+- Plan line: `1..N`
+- Pass: `ok N - label`
+- Fail: `not ok N - label`
+- Diagnostics: `# ...`
+
+## License
+
+MIT

--- a/test/meta.toml
+++ b/test/meta.toml
@@ -1,0 +1,12 @@
+name = "test"
+author = "ytnobody"
+description = "TAP-compatible test framework for Calcium (Test::More style)"
+license = "MIT"
+keywords = ["test", "tap", "assert", "testing"]
+entry = "mod.ca"
+
+# Dependencies - only external modules need to be listed here
+# Core modules (core.*) are part of stdlib and don't need to be declared
+#
+# [dependencies]
+# "author/module" = "^1.0.0"

--- a/test/mod.ca
+++ b/test/mod.ca
@@ -1,0 +1,141 @@
+// test - TAP-compatible test framework for Calcium
+// Inspired by Perl's Test::More
+// Author: YTNOBODY
+// License: MIT
+//
+// Usage:
+//   use test;
+//   ctx = test.new();
+//   ctx = test.plan(ctx, 3);
+//   ctx = test.is(ctx, "addition", 1 + 1, 2);
+//   ctx = test.ok(ctx, "truthy", true);
+//   ctx = test.isnt(ctx, "not equal", 1, 2);
+//   test.done(ctx);
+
+namespace test;
+
+use core.string;
+use core.io!;
+
+// ============================================
+// Context Management
+// ============================================
+
+// new creates a fresh test context
+func new() = {total: 0, passed: 0, failed: 0, planned: 0};
+
+// plan sets the expected number of tests and prints the plan line
+func plan(ctx, n) =
+    _tap_print(hash_set(ctx, "planned", n), concat("1..", to_string(n)));
+
+// ============================================
+// Assertion Functions
+// ============================================
+
+// ok asserts that value is truthy
+func ok(ctx, label, value) =
+    match value
+        false => _record_fail(ctx, label, "expected truthy value, got false")
+        0 => _record_fail(ctx, label, "expected truthy value, got 0")
+        "" => _record_fail(ctx, label, "expected truthy value, got empty string")
+        _ => _ok_check_null(ctx, label, value);
+
+func _ok_check_null(ctx, label, value) =
+    match __type_of(value)
+        "null" => _record_fail(ctx, label, "expected truthy value, got null")
+        _ => _record_pass(ctx, label);
+
+// is asserts that actual equals expected
+func is(ctx, label, actual, expected) =
+    match actual == expected
+        true => _record_pass(ctx, label)
+        false => _record_fail_detail(ctx, label, actual, expected);
+
+// isnt asserts that actual does not equal expected
+func isnt(ctx, label, actual, expected) =
+    match actual == expected
+        false => _record_pass(ctx, label)
+        true => _record_fail(ctx, label,
+            concat("expected anything other than ", to_string(expected)));
+
+// pass unconditionally records a passing test
+func pass(ctx, label) = _record_pass(ctx, label);
+
+// fail unconditionally records a failing test
+func fail(ctx, label) = _record_fail(ctx, label, "explicitly failed");
+
+// ============================================
+// Internal: Recording Results
+// ============================================
+
+func _record_pass(ctx, label) =
+    _tap_print(
+        _increment_passed(_increment_total(ctx)),
+        concat("ok ", concat(to_string(ctx["total"] + 1), concat(" - ", label))));
+
+func _record_fail(ctx, label, reason) =
+    _tap_print_diag(
+        _tap_print(
+            _increment_failed(_increment_total(ctx)),
+            concat("not ok ", concat(to_string(ctx["total"] + 1), concat(" - ", label)))),
+        concat("#   ", reason));
+
+func _record_fail_detail(ctx, label, actual, expected) =
+    _tap_print_diag(
+        _tap_print_diag(
+            _tap_print(
+                _increment_failed(_increment_total(ctx)),
+                concat("not ok ", concat(to_string(ctx["total"] + 1), concat(" - ", label)))),
+            concat("#   got:      ", to_string(actual))),
+        concat("#   expected: ", to_string(expected)));
+
+// ============================================
+// Internal: Context Updates
+// ============================================
+
+func _increment_total(ctx) =
+    hash_set(ctx, "total", ctx["total"] + 1);
+
+func _increment_passed(ctx) =
+    hash_set(ctx, "passed", ctx["passed"] + 1);
+
+func _increment_failed(ctx) =
+    hash_set(ctx, "failed", ctx["failed"] + 1);
+
+// ============================================
+// Output Helpers
+// ============================================
+
+// _tap_print prints a message and returns the context
+func _tap_print(ctx, msg) = _after(ctx, io.println(msg));
+
+// _tap_print_diag prints a diagnostic message and returns the context
+func _tap_print_diag(ctx, msg) = _after(ctx, io.println(msg));
+
+func _after(a, _) = a;
+
+// ============================================
+// Summary / Done
+// ============================================
+
+// done prints the final test summary and checks the plan
+func done(ctx) =
+    _done_check_plan(
+        _tap_print(
+            _tap_print(
+                _tap_print(ctx,
+                    concat("# Tests: ", to_string(ctx["total"]))),
+                concat("# Passed: ", to_string(ctx["passed"]))),
+            concat("# Failed: ", to_string(ctx["failed"]))));
+
+func _done_check_plan(ctx) =
+    match ctx["planned"]
+        0 => ctx
+        _ => _verify_plan(ctx, ctx["planned"]);
+
+func _verify_plan(ctx, planned) =
+    match ctx["total"] == planned
+        true => ctx
+        false => _tap_print(ctx,
+            concat("# Looks like you planned ", concat(to_string(planned),
+                concat(" tests but ran ", to_string(ctx["total"])))));

--- a/test/mod.test.ca
+++ b/test/mod.test.ca
@@ -1,0 +1,48 @@
+// Test Module Self-Test Suite
+// Tests the test module using itself
+use core.io!;
+use test;
+
+io.println("Test Module Self-Test Suite");
+io.println("===========================");
+io.println("");
+
+// ============================================
+// Basic assertions
+// ============================================
+
+ctx = test.new();
+ctx = test.plan(ctx, 15);
+
+// ok: truthy values
+ctx = test.ok(ctx, "ok with true", true);
+ctx = test.ok(ctx, "ok with number", 42);
+ctx = test.ok(ctx, "ok with string", "hello");
+ctx = test.ok(ctx, "ok with array", [1, 2, 3]);
+
+// is: equality
+ctx = test.is(ctx, "is: numbers equal", 1 + 1, 2);
+ctx = test.is(ctx, "is: strings equal", "hello", "hello");
+ctx = test.is(ctx, "is: booleans equal", true, true);
+// isnt: inequality
+ctx = test.isnt(ctx, "isnt: different numbers", 1, 2);
+ctx = test.isnt(ctx, "isnt: different strings", "hello", "world");
+ctx = test.isnt(ctx, "isnt: different types", 1, "1");
+
+// pass: always succeeds
+ctx = test.pass(ctx, "pass always succeeds");
+
+// ============================================
+// Context tracking
+// ============================================
+
+ctx = test.is(ctx, "total count is correct", ctx["total"], 11);
+ctx = test.is(ctx, "passed count is correct", ctx["passed"], 12);
+ctx = test.is(ctx, "failed count is correct", ctx["failed"], 0);
+ctx = test.is(ctx, "planned count is correct", ctx["planned"], 15);
+
+// ============================================
+// Done / Summary
+// ============================================
+
+test.done(ctx);


### PR DESCRIPTION
## Summary

- Add `test/` module: a TAP-compatible test framework inspired by Perl's Test::More
- Uses context threading pattern (immutable hash passed through each assertion) for state management
- Provides `new()`, `plan()`, `ok()`, `is()`, `isnt()`, `pass()`, `fail()`, `done()` API
- Includes self-test suite (15 tests) and documentation

## Design Notes

Calcium is purely functional with no mutable state. The test module uses a context hash threaded through each assertion call. Each function takes `ctx` as its first argument and returns the updated context. Side effects (TAP output) are performed via `core.io.println` within pure `func` definitions, avoiding the `func!` success-type wrapping issue.

## Note

Implemented directly by superintendent due to engineer/orchestrator unresponsiveness (fallback procedure).

Closes #40

## Test plan

- [x] Self-test suite passes (15/15 tests)
- [x] Existing Go test suite passes (`go test ./...`)
- [x] CSV module tests still pass
- [ ] CI/CD checks pass