### PR TITLE
gh-50: add core.json standard library module

### DIFF
--- a/pkg/vm/primitives.go
+++ b/pkg/vm/primitives.go
@@ -1390,6 +1390,10 @@ func GetPrimitives() map[string]*value.Builtin {
 		"__toml_parse":     {Name: "__toml_parse", Fn: primitiveTomlParse},
 		"__toml_stringify": {Name: "__toml_stringify", Fn: primitiveTomlStringify},
 
+		// JSON
+		"__json_parse":     {Name: "__json_parse", Fn: primitiveJSONParse},
+		"__json_stringify": {Name: "__json_stringify", Fn: primitiveJSONStringify},
+
 		// HTTP
 		"__http_get":     {Name: "__http_get", Fn: primitiveHttpGet},
 		"__http_post":    {Name: "__http_post", Fn: primitiveHttpPost},

--- a/pkg/vm/primitives_json.go
+++ b/pkg/vm/primitives_json.go
@@ -1,0 +1,400 @@
+package vm
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/ytnobody/calcium-lang/pkg/value"
+)
+
+// primitiveJSONParse parses a JSON string into a Calcium value
+func primitiveJSONParse(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__json_parse: expected 1 argument (json string)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("__json_parse: argument must be string"))
+	}
+	s := args[0].AsString()
+	result, pos, err := parseJSONValue(s, 0)
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("__json_parse: %v", err)))
+	}
+	// Check for trailing content (after skipping whitespace)
+	pos = skipJSONWhitespace(s, pos)
+	if pos < len(s) {
+		return value.Failure(value.String(fmt.Sprintf("__json_parse: unexpected content at position %d", pos)))
+	}
+	return value.Success(result)
+}
+
+// primitiveJSONStringify converts a Calcium value to a JSON string
+func primitiveJSONStringify(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__json_stringify: expected 1 argument"))
+	}
+	result, err := stringifyJSON(args[0])
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("__json_stringify: %v", err)))
+	}
+	return value.Success(value.String(result))
+}
+
+// --- JSON Parser ---
+
+func skipJSONWhitespace(s string, pos int) int {
+	for pos < len(s) {
+		c := s[pos]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			pos++
+		} else {
+			break
+		}
+	}
+	return pos
+}
+
+func parseJSONValue(s string, pos int) (value.Value, int, error) {
+	pos = skipJSONWhitespace(s, pos)
+	if pos >= len(s) {
+		return value.Null(), pos, fmt.Errorf("unexpected end of input")
+	}
+	switch s[pos] {
+	case '"':
+		return parseJSONString(s, pos)
+	case '{':
+		return parseJSONObject(s, pos)
+	case '[':
+		return parseJSONArray(s, pos)
+	case 't':
+		return parseJSONTrue(s, pos)
+	case 'f':
+		return parseJSONFalse(s, pos)
+	case 'n':
+		return parseJSONNull(s, pos)
+	default:
+		if s[pos] == '-' || (s[pos] >= '0' && s[pos] <= '9') {
+			return parseJSONNumber(s, pos)
+		}
+		return value.Null(), pos, fmt.Errorf("unexpected character: %c at position %d", s[pos], pos)
+	}
+}
+
+func parseJSONString(s string, pos int) (value.Value, int, error) {
+	if pos >= len(s) || s[pos] != '"' {
+		return value.Null(), pos, fmt.Errorf("expected '\"' at position %d", pos)
+	}
+	pos++ // skip opening quote
+	var buf strings.Builder
+	for pos < len(s) {
+		c := s[pos]
+		if c == '"' {
+			return value.String(buf.String()), pos + 1, nil
+		}
+		if c == '\\' {
+			pos++
+			if pos >= len(s) {
+				return value.Null(), pos, fmt.Errorf("unexpected end of string escape")
+			}
+			esc := s[pos]
+			switch esc {
+			case '"':
+				buf.WriteByte('"')
+			case '\\':
+				buf.WriteByte('\\')
+			case '/':
+				buf.WriteByte('/')
+			case 'b':
+				buf.WriteByte('\b')
+			case 'f':
+				buf.WriteByte('\f')
+			case 'n':
+				buf.WriteByte('\n')
+			case 'r':
+				buf.WriteByte('\r')
+			case 't':
+				buf.WriteByte('\t')
+			case 'u':
+				if pos+4 >= len(s) {
+					return value.Null(), pos, fmt.Errorf("incomplete unicode escape")
+				}
+				hex := s[pos+1 : pos+5]
+				codepoint, err := strconv.ParseUint(hex, 16, 32)
+				if err != nil {
+					return value.Null(), pos, fmt.Errorf("invalid unicode escape: \\u%s", hex)
+				}
+				r := rune(codepoint)
+				// Handle surrogate pairs
+				if r >= 0xD800 && r <= 0xDBFF {
+					if pos+10 < len(s) && s[pos+5] == '\\' && s[pos+6] == 'u' {
+						hex2 := s[pos+7 : pos+11]
+						low, err := strconv.ParseUint(hex2, 16, 32)
+						if err == nil && low >= 0xDC00 && low <= 0xDFFF {
+							r = 0x10000 + (r-0xD800)*0x400 + (rune(low) - 0xDC00)
+							pos += 6
+						}
+					}
+				}
+				var ubuf [4]byte
+				n := utf8.EncodeRune(ubuf[:], r)
+				buf.Write(ubuf[:n])
+				pos += 4
+			default:
+				buf.WriteByte(esc)
+			}
+			pos++
+			continue
+		}
+		buf.WriteByte(c)
+		pos++
+	}
+	return value.Null(), pos, fmt.Errorf("unterminated string")
+}
+
+func parseJSONNumber(s string, pos int) (value.Value, int, error) {
+	start := pos
+	if pos < len(s) && s[pos] == '-' {
+		pos++
+	}
+	if pos >= len(s) || s[pos] < '0' || s[pos] > '9' {
+		return value.Null(), pos, fmt.Errorf("invalid number at position %d", start)
+	}
+	for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+		pos++
+	}
+	isFloat := false
+	if pos < len(s) && s[pos] == '.' {
+		isFloat = true
+		pos++
+		for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+			pos++
+		}
+	}
+	if pos < len(s) && (s[pos] == 'e' || s[pos] == 'E') {
+		isFloat = true
+		pos++
+		if pos < len(s) && (s[pos] == '+' || s[pos] == '-') {
+			pos++
+		}
+		for pos < len(s) && s[pos] >= '0' && s[pos] <= '9' {
+			pos++
+		}
+	}
+	numStr := s[start:pos]
+	if isFloat {
+		f, err := strconv.ParseFloat(numStr, 64)
+		if err != nil {
+			return value.Null(), pos, fmt.Errorf("invalid float: %s", numStr)
+		}
+		return value.Float(f), pos, nil
+	}
+	i, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		f, ferr := strconv.ParseFloat(numStr, 64)
+		if ferr != nil {
+			return value.Null(), pos, fmt.Errorf("invalid number: %s", numStr)
+		}
+		return value.Float(f), pos, nil
+	}
+	return value.Int(i), pos, nil
+}
+
+func parseJSONTrue(s string, pos int) (value.Value, int, error) {
+	if pos+4 <= len(s) && s[pos:pos+4] == "true" {
+		return value.Bool(true), pos + 4, nil
+	}
+	return value.Null(), pos, fmt.Errorf("expected 'true' at position %d", pos)
+}
+
+func parseJSONFalse(s string, pos int) (value.Value, int, error) {
+	if pos+5 <= len(s) && s[pos:pos+5] == "false" {
+		return value.Bool(false), pos + 5, nil
+	}
+	return value.Null(), pos, fmt.Errorf("expected 'false' at position %d", pos)
+}
+
+func parseJSONNull(s string, pos int) (value.Value, int, error) {
+	if pos+4 <= len(s) && s[pos:pos+4] == "null" {
+		return value.Null(), pos + 4, nil
+	}
+	return value.Null(), pos, fmt.Errorf("expected 'null' at position %d", pos)
+}
+
+func parseJSONArray(s string, pos int) (value.Value, int, error) {
+	pos++ // skip '['
+	pos = skipJSONWhitespace(s, pos)
+	if pos >= len(s) {
+		return value.Null(), pos, fmt.Errorf("unterminated array")
+	}
+	if s[pos] == ']' {
+		return value.Array(nil), pos + 1, nil
+	}
+	var elements []value.Value
+	for {
+		elem, next, err := parseJSONValue(s, pos)
+		if err != nil {
+			return value.Null(), next, err
+		}
+		elements = append(elements, elem)
+		pos = skipJSONWhitespace(s, next)
+		if pos >= len(s) {
+			return value.Null(), pos, fmt.Errorf("unterminated array")
+		}
+		if s[pos] == ']' {
+			return value.Array(elements), pos + 1, nil
+		}
+		if s[pos] != ',' {
+			return value.Null(), pos, fmt.Errorf("expected ',' or ']' in array at position %d", pos)
+		}
+		pos++
+		pos = skipJSONWhitespace(s, pos)
+		if pos < len(s) && s[pos] == ']' {
+			return value.Null(), pos, fmt.Errorf("trailing comma in array at position %d", pos)
+		}
+	}
+}
+
+func parseJSONObject(s string, pos int) (value.Value, int, error) {
+	pos++ // skip '{'
+	pos = skipJSONWhitespace(s, pos)
+	if pos >= len(s) {
+		return value.Null(), pos, fmt.Errorf("unterminated object")
+	}
+	if s[pos] == '}' {
+		h := value.NewHash()
+		return value.HashVal(h), pos + 1, nil
+	}
+	h := value.NewHash()
+	for {
+		if pos >= len(s) || s[pos] != '"' {
+			return value.Null(), pos, fmt.Errorf("expected string key in object at position %d", pos)
+		}
+		keyVal, next, err := parseJSONString(s, pos)
+		if err != nil {
+			return value.Null(), next, err
+		}
+		pos = skipJSONWhitespace(s, next)
+		if pos >= len(s) || s[pos] != ':' {
+			return value.Null(), pos, fmt.Errorf("expected ':' after object key at position %d", pos)
+		}
+		pos++
+		val, next2, err := parseJSONValue(s, pos)
+		if err != nil {
+			return value.Null(), next2, err
+		}
+		h.Set(keyVal, val)
+		pos = skipJSONWhitespace(s, next2)
+		if pos >= len(s) {
+			return value.Null(), pos, fmt.Errorf("unterminated object")
+		}
+		if s[pos] == '}' {
+			return value.HashVal(h), pos + 1, nil
+		}
+		if s[pos] != ',' {
+			return value.Null(), pos, fmt.Errorf("expected ',' or '}' in object at position %d", pos)
+		}
+		pos++
+		pos = skipJSONWhitespace(s, pos)
+		if pos < len(s) && s[pos] == '}' {
+			return value.Null(), pos, fmt.Errorf("trailing comma in object at position %d", pos)
+		}
+	}
+}
+
+// --- JSON Stringify ---
+
+func stringifyJSON(v value.Value) (string, error) {
+	var buf strings.Builder
+	if err := writeJSON(&buf, v); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func writeJSON(buf *strings.Builder, v value.Value) error {
+	switch v.Type {
+	case value.TYPE_NULL:
+		buf.WriteString("null")
+	case value.TYPE_BOOL:
+		if v.AsBool() {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case value.TYPE_INT:
+		buf.WriteString(strconv.FormatInt(v.AsInt(), 10))
+	case value.TYPE_FLOAT:
+		f := v.AsFloat()
+		if math.IsInf(f, 0) || math.IsNaN(f) {
+			buf.WriteString("null")
+		} else {
+			buf.WriteString(strconv.FormatFloat(f, 'f', -1, 64))
+		}
+	case value.TYPE_STRING:
+		writeJSONString(buf, v.AsString())
+	case value.TYPE_ARRAY:
+		arr := v.AsArray()
+		buf.WriteByte('[')
+		for i, elem := range arr {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := writeJSON(buf, elem); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case value.TYPE_HASH:
+		h := v.AsHash()
+		buf.WriteByte('{')
+		first := true
+		for _, pair := range h.Pairs {
+			if first {
+				first = false
+			} else {
+				buf.WriteByte(',')
+			}
+			writeJSONString(buf, pair.Key.AsString())
+			buf.WriteByte(':')
+			if err := writeJSON(buf, pair.Value); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	default:
+		writeJSONString(buf, v.String())
+	}
+	return nil
+}
+
+func writeJSONString(buf *strings.Builder, s string) {
+	buf.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\f':
+			buf.WriteString(`\f`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(buf, `\u%04x`, r)
+			} else {
+				buf.WriteRune(r)
+			}
+		}
+	}
+	buf.WriteByte('"')
+}

--- a/pkg/vm/primitives_json_test.go
+++ b/pkg/vm/primitives_json_test.go
@@ -1,0 +1,213 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ytnobody/calcium-lang/pkg/value"
+)
+
+func assertJSONSuccess(t *testing.T, result value.Value) value.Value {
+	t.Helper()
+	if result.Type != value.TYPE_SUCCESS {
+		t.Fatalf("expected success, got %s: %s", result.Type, result.String())
+	}
+	return result.AsSuccess()
+}
+
+func assertJSONFailure(t *testing.T, result value.Value) {
+	t.Helper()
+	if result.Type != value.TYPE_FAILURE {
+		t.Fatalf("expected failure, got %s: %s", result.Type, result.String())
+	}
+}
+
+func TestJSONParsePrimitives(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected value.Value
+	}{
+		{"integer", "42", value.Int(42)},
+		{"negative integer", "-17", value.Int(-17)},
+		{"zero", "0", value.Int(0)},
+		{"float", "3.14", value.Float(3.14)},
+		{"negative float", "-0.5", value.Float(-0.5)},
+		{"exponent", "1e3", value.Float(1000)},
+		{"true", "true", value.Bool(true)},
+		{"false", "false", value.Bool(false)},
+		{"null", "null", value.Null()},
+		{"simple string", `"hello"`, value.String("hello")},
+		{"empty string", `""`, value.String("")},
+		{"string with escape", `"hello\nworld"`, value.String("hello\nworld")},
+		{"string with tab", `"a\tb"`, value.String("a\tb")},
+		{"string with unicode", `"caf\u00e9"`, value.String("caf\u00e9")},
+		{"number with whitespace", "  42  ", value.Int(42)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := primitiveJSONParse(value.String(tt.input))
+			v := assertJSONSuccess(t, result)
+			if v.String() != tt.expected.String() {
+				t.Errorf("expected %s, got %s", tt.expected.String(), v.String())
+			}
+		})
+	}
+}
+
+func TestJSONParseArray(t *testing.T) {
+	v := assertJSONSuccess(t, primitiveJSONParse(value.String("[1, 2, 3]")))
+	arr := v.AsArray()
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(arr))
+	}
+	if arr[0].AsInt() != 1 || arr[1].AsInt() != 2 || arr[2].AsInt() != 3 {
+		t.Errorf("expected [1,2,3], got %v", arr)
+	}
+}
+
+func TestJSONParseEmptyArray(t *testing.T) {
+	v := assertJSONSuccess(t, primitiveJSONParse(value.String("[]")))
+	arr := v.AsArray()
+	if len(arr) != 0 {
+		t.Fatalf("expected empty array, got %d elements", len(arr))
+	}
+}
+
+func TestJSONParseObject(t *testing.T) {
+	v := assertJSONSuccess(t, primitiveJSONParse(value.String(`{"name": "Alice", "age": 30}`)))
+	h := v.AsHash()
+	nameVal, ok := h.Get(value.String("name"))
+	if !ok {
+		t.Fatal("expected key 'name'")
+	}
+	if nameVal.AsString() != "Alice" {
+		t.Errorf("expected 'Alice', got '%s'", nameVal.AsString())
+	}
+	ageVal, ok := h.Get(value.String("age"))
+	if !ok {
+		t.Fatal("expected key 'age'")
+	}
+	if ageVal.AsInt() != 30 {
+		t.Errorf("expected 30, got %d", ageVal.AsInt())
+	}
+}
+
+func TestJSONParseNested(t *testing.T) {
+	input := `{"users": [{"name": "Alice", "scores": [95, 87]}, {"name": "Bob"}]}`
+	v := assertJSONSuccess(t, primitiveJSONParse(value.String(input)))
+	h := v.AsHash()
+	users, ok := h.Get(value.String("users"))
+	if !ok {
+		t.Fatal("expected key 'users'")
+	}
+	arr := users.AsArray()
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(arr))
+	}
+	user0 := arr[0].AsHash()
+	name0, _ := user0.Get(value.String("name"))
+	if name0.AsString() != "Alice" {
+		t.Errorf("expected 'Alice', got '%s'", name0.AsString())
+	}
+	scores, _ := user0.Get(value.String("scores"))
+	scoresArr := scores.AsArray()
+	if len(scoresArr) != 2 || scoresArr[0].AsInt() != 95 {
+		t.Errorf("unexpected scores: %v", scoresArr)
+	}
+}
+
+func TestJSONParseErrors(t *testing.T) {
+	errCases := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"unclosed brace", "{"},
+		{"unclosed bracket", "["},
+		{"trailing comma array", "[1, 2,]"},
+		{"trailing comma object", `{"a": 1,}`},
+		{"invalid token", "invalid"},
+		{"missing colon", `{"a" 1}`},
+	}
+
+	for _, tt := range errCases {
+		t.Run(tt.name, func(t *testing.T) {
+			result := primitiveJSONParse(value.String(tt.input))
+			assertJSONFailure(t, result)
+		})
+	}
+}
+
+func TestJSONStringify(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    value.Value
+		expected string
+	}{
+		{"int", value.Int(42), "42"},
+		{"negative int", value.Int(-17), "-17"},
+		{"float", value.Float(3.14), "3.14"},
+		{"true", value.Bool(true), "true"},
+		{"false", value.Bool(false), "false"},
+		{"null", value.Null(), "null"},
+		{"string", value.String("hello"), `"hello"`},
+		{"empty string", value.String(""), `""`},
+		{"string with newline", value.String("a\nb"), `"a\nb"`},
+		{"empty array", value.Array(nil), "[]"},
+		{"int array", value.Array([]value.Value{value.Int(1), value.Int(2), value.Int(3)}), "[1,2,3]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := assertJSONSuccess(t, primitiveJSONStringify(tt.input))
+			if v.AsString() != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, v.AsString())
+			}
+		})
+	}
+}
+
+func TestJSONStringifyObject(t *testing.T) {
+	h := value.NewHash()
+	h.Set(value.String("name"), value.String("Alice"))
+	h.Set(value.String("age"), value.Int(30))
+
+	v := assertJSONSuccess(t, primitiveJSONStringify(value.HashVal(h)))
+	expected := `{"name":"Alice","age":30}`
+	if v.AsString() != expected {
+		t.Errorf("expected %s, got %s", expected, v.AsString())
+	}
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	inputs := []string{
+		"42",
+		"3.14",
+		"true",
+		"false",
+		"null",
+		`"hello"`,
+		"[1,2,3]",
+		`{"name":"Alice","age":30}`,
+		`[{"id":1},{"id":2}]`,
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			parsed := assertJSONSuccess(t, primitiveJSONParse(value.String(input)))
+			stringified := assertJSONSuccess(t, primitiveJSONStringify(parsed))
+			if stringified.AsString() != input {
+				t.Errorf("round-trip mismatch: %s -> %s", input, stringified.AsString())
+			}
+		})
+	}
+}
+
+func TestJSONParseWrongArgType(t *testing.T) {
+	assertJSONFailure(t, primitiveJSONParse(value.Int(42)))
+}
+
+func TestJSONParseWrongArgCount(t *testing.T) {
+	assertJSONFailure(t, primitiveJSONParse())
+}

--- a/pkg/vm/stdlib/core/json.ca
+++ b/pkg/vm/stdlib/core/json.ca
@@ -1,0 +1,20 @@
+// core.json - JSON parser / serializer
+// Uses primitives: __json_parse, __json_stringify
+
+// parse converts a JSON string to a Calcium value
+// Returns success(value) on success, failure(message) on error
+// Supports: strings, numbers (int/float), booleans, null, arrays, objects
+// Example: json.parse('{"name": "Alice", "age": 30}')
+func parse(s) = __json_parse(s);
+
+// stringify converts a Calcium value to a JSON string
+// Returns success(string) on success, failure(message) on error
+// Supports: strings, numbers, booleans, null, arrays, hashes
+// Example: json.stringify({name: "Alice", age: 30})
+func stringify(v) = __json_stringify(v);
+
+// decode is an alias for parse
+func decode(s) = parse(s);
+
+// encode is an alias for stringify
+func encode(v) = stringify(v);

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1136,6 +1136,40 @@ func TestCoreArrayModule(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+// Test core.json module
+func TestCoreJSONModule(t *testing.T) {
+	tests := []vmTestCase{
+		// Parse integers
+		{`use core.json; json.parse("42") !? { success(v) => v failure(e) => 0 };`, int64(42)},
+		{`use core.json; json.parse("-17") !? { success(v) => v failure(e) => 0 };`, int64(-17)},
+		// Parse float
+		{`use core.json; json.parse("3.14") !? { success(v) => v failure(e) => 0.0 };`, 3.14},
+		// Parse booleans
+		{`use core.json; json.parse("true") !? { success(v) => v failure(e) => false };`, true},
+		{`use core.json; json.parse("false") !? { success(v) => v failure(e) => true };`, false},
+		// Parse strings
+		{`use core.json; json.parse('"hello"') !? { success(v) => v failure(e) => "" };`, "hello"},
+		// Parse arrays
+		{`use core.json; json.parse("[1, 2, 3]") !? { success(v) => v[0] failure(e) => 0 };`, int64(1)},
+		{`use core.json; json.parse("[1, 2, 3]") !? { success(v) => len(v) failure(e) => 0 };`, int64(3)},
+		// Parse objects
+		{`use core.json; json.parse('{"name": "Alice"}') !? { success(v) => v["name"] failure(e) => "" };`, "Alice"},
+		// Stringify
+		{`use core.json; json.stringify(42) !? { success(v) => v failure(e) => "" };`, "42"},
+		{`use core.json; json.stringify(true) !? { success(v) => v failure(e) => "" };`, "true"},
+		{`use core.json; json.stringify("hello") !? { success(v) => v failure(e) => "" };`, `"hello"`},
+		{`use core.json; json.stringify([1, 2, 3]) !? { success(v) => v failure(e) => "" };`, "[1,2,3]"},
+		// Round-trip
+		{`use core.json; json.parse(json.stringify(42) !? { success(v) => v failure(_) => "" }) !? { success(v) => v failure(_) => 0 };`, int64(42)},
+		// Aliases
+		{`use core.json; json.decode("42") !? { success(v) => v failure(e) => 0 };`, int64(42)},
+		{`use core.json; json.encode(42) !? { success(v) => v failure(e) => "" };`, "42"},
+		// Error case
+		{`use core.json; json.parse("invalid") !? { success(v) => "ok" failure(e) => "error" };`, "error"},
+	}
+	runVmTests(t, tests)
+}
+
 func TestHashLiterals(t *testing.T) {
 	tests := []vmTestCase{
 		// Empty hash

--- a/tests/json.test.ca
+++ b/tests/json.test.ca
@@ -1,0 +1,200 @@
+// JSON Module Test Suite (core.json)
+use core.io!;
+use core.json;
+use test;
+
+io.println("# core.json Module Tests");
+
+ctx = test.new();
+ctx = test.plan(ctx, 30);
+
+// ============================================
+// parse: Numbers
+// ============================================
+
+io.println("# parse: Numbers");
+
+json.parse("42") !? {
+    success(v) => ctx = test.is(ctx, "parse integer", v, 42)
+    failure(e) => ctx = test.fail(ctx, "parse integer")
+};
+json.parse("-17") !? {
+    success(v) => ctx = test.is(ctx, "parse negative integer", v, -17)
+    failure(e) => ctx = test.fail(ctx, "parse negative integer")
+};
+json.parse("3.14") !? {
+    success(v) => ctx = test.is(ctx, "parse float", v, 3.14)
+    failure(e) => ctx = test.fail(ctx, "parse float")
+};
+json.parse("0") !? {
+    success(v) => ctx = test.is(ctx, "parse zero", v, 0)
+    failure(e) => ctx = test.fail(ctx, "parse zero")
+};
+
+// ============================================
+// parse: Booleans and Null
+// ============================================
+
+io.println("# parse: Booleans and Null");
+
+json.parse("true") !? {
+    success(v) => ctx = test.is(ctx, "parse true", v, true)
+    failure(e) => ctx = test.fail(ctx, "parse true")
+};
+json.parse("false") !? {
+    success(v) => ctx = test.is(ctx, "parse false", v, false)
+    failure(e) => ctx = test.fail(ctx, "parse false")
+};
+
+// ============================================
+// parse: Strings
+// ============================================
+
+io.println("# parse: Strings");
+
+json.parse('"hello"') !? {
+    success(v) => ctx = test.is(ctx, "parse string", v, "hello")
+    failure(e) => ctx = test.fail(ctx, "parse string")
+};
+json.parse('""') !? {
+    success(v) => ctx = test.is(ctx, "parse empty string", v, "")
+    failure(e) => ctx = test.fail(ctx, "parse empty string")
+};
+json.parse('"hello world"') !? {
+    success(v) => ctx = test.is(ctx, "parse string with space", v, "hello world")
+    failure(e) => ctx = test.fail(ctx, "parse string with space")
+};
+
+// ============================================
+// parse: Arrays
+// ============================================
+
+io.println("# parse: Arrays");
+
+json.parse("[]") !? {
+    success(v) => ctx = test.is(ctx, "parse empty array length", len(v), 0)
+    failure(e) => ctx = test.fail(ctx, "parse empty array")
+};
+json.parse("[1, 2, 3]") !? {
+    success(v) => ctx = test.is(ctx, "parse array first", v[0], 1)
+    failure(e) => ctx = test.fail(ctx, "parse array first")
+};
+json.parse("[1, 2, 3]") !? {
+    success(v) => ctx = test.is(ctx, "parse array length", len(v), 3)
+    failure(e) => ctx = test.fail(ctx, "parse array length")
+};
+
+// ============================================
+// parse: Objects
+// ============================================
+
+io.println("# parse: Objects");
+
+json.parse('{"name": "Alice", "age": 30}') !? {
+    success(v) => ctx = test.is(ctx, "parse object string value", v["name"], "Alice")
+    failure(e) => ctx = test.fail(ctx, "parse object string value")
+};
+json.parse('{"name": "Alice", "age": 30}') !? {
+    success(v) => ctx = test.is(ctx, "parse object number value", v["age"], 30)
+    failure(e) => ctx = test.fail(ctx, "parse object number value")
+};
+
+// ============================================
+// parse: Nested structures
+// ============================================
+
+io.println("# parse: Nested structures");
+
+json.parse('{"numbers": [1, 2, 3]}') !? {
+    success(v) => ctx = test.is(ctx, "parse object with array length", len(v["numbers"]), 3)
+    failure(e) => ctx = test.fail(ctx, "parse object with array")
+};
+json.parse('[{"id": 1}, {"id": 2}]') !? {
+    success(v) => ctx = test.is(ctx, "parse array of objects", v[1]["id"], 2)
+    failure(e) => ctx = test.fail(ctx, "parse array of objects")
+};
+
+// ============================================
+// stringify: Primitives
+// ============================================
+
+io.println("# stringify: Primitives");
+
+json.stringify(42) !? {
+    success(v) => ctx = test.is(ctx, "stringify int", v, "42")
+    failure(e) => ctx = test.fail(ctx, "stringify int")
+};
+json.stringify(true) !? {
+    success(v) => ctx = test.is(ctx, "stringify true", v, "true")
+    failure(e) => ctx = test.fail(ctx, "stringify true")
+};
+json.stringify(false) !? {
+    success(v) => ctx = test.is(ctx, "stringify false", v, "false")
+    failure(e) => ctx = test.fail(ctx, "stringify false")
+};
+json.stringify("hello") !? {
+    success(v) => ctx = test.is(ctx, "stringify string", v, '"hello"')
+    failure(e) => ctx = test.fail(ctx, "stringify string")
+};
+
+// ============================================
+// stringify: Arrays
+// ============================================
+
+io.println("# stringify: Arrays");
+
+json.stringify([]) !? {
+    success(v) => ctx = test.is(ctx, "stringify empty array", v, "[]")
+    failure(e) => ctx = test.fail(ctx, "stringify empty array")
+};
+json.stringify([1, 2, 3]) !? {
+    success(v) => ctx = test.is(ctx, "stringify int array", v, "[1,2,3]")
+    failure(e) => ctx = test.fail(ctx, "stringify int array")
+};
+
+// ============================================
+// Round-trip
+// ============================================
+
+io.println("# Round-trip");
+
+json.parse(json.stringify(42) !? { success(v) => v failure(_) => "" }) !? {
+    success(v) => ctx = test.is(ctx, "round-trip integer", v, 42)
+    failure(e) => ctx = test.fail(ctx, "round-trip integer")
+};
+json.parse(json.stringify([1, 2, 3]) !? { success(v) => v failure(_) => "" }) !? {
+    success(v) => ctx = test.is(ctx, "round-trip array first", v[0], 1)
+    failure(e) => ctx = test.fail(ctx, "round-trip array")
+};
+
+// ============================================
+// Error cases
+// ============================================
+
+io.println("# Error cases");
+
+json.parse("") !? {
+    success(_) => ctx = test.fail(ctx, "empty input should fail")
+    failure(e) => ctx = test.pass(ctx, "empty input returns failure")
+};
+json.parse("invalid") !? {
+    success(_) => ctx = test.fail(ctx, "invalid input should fail")
+    failure(e) => ctx = test.pass(ctx, "invalid input returns failure")
+};
+
+// ============================================
+// Aliases
+// ============================================
+
+io.println("# Aliases");
+
+json.decode("42") !? {
+    success(v) => ctx = test.is(ctx, "decode alias", v, 42)
+    failure(e) => ctx = test.fail(ctx, "decode alias")
+};
+json.encode(42) !? {
+    success(v) => ctx = test.is(ctx, "encode alias", v, "42")
+    failure(e) => ctx = test.fail(ctx, "encode alias")
+};
+
+test.done(ctx);


### PR DESCRIPTION
Issue: gh-50

## Summary

- Add `core.json` standard library module with `json.parse` and `json.stringify` functions
- Implement full JSON parser supporting strings, numbers (int/float), booleans, null, arrays, and objects with proper escape sequence and surrogate pair handling
- Implement JSON serializer for all Calcium value types
- Add `decode` / `encode` aliases for `parse` / `stringify`
- Register `__json_parse` and `__json_stringify` primitives in the VM

## Changes

- `pkg/vm/primitives_json.go` - JSON parser and serializer implementation in Go
- `pkg/vm/primitives_json_test.go` - Go unit tests for primitives (parse, stringify, error cases, round-trips)
- `pkg/vm/primitives.go` - Register new JSON primitives in `GetPrimitives()`
- `pkg/vm/stdlib/core/json.ca` - Calcium wrapper module exposing `parse`, `stringify`, `decode`, `encode`
- `pkg/vm/vm_test.go` - VM integration tests via `TestCoreJSONModule`
- `tests/json.test.ca` - Calcium test suite with 30 test cases