### PR TITLE
gh-68: enable pipeline chaining for test API

### DIFF
--- a/test/mod.ca
+++ b/test/mod.ca
@@ -3,14 +3,14 @@
 // Author: YTNOBODY
 // License: MIT
 //
-// Usage:
+// Usage (pipeline chaining style):
 //   use test;
-//   ctx = test.new();
-//   ctx = test.plan(ctx, 3);
-//   ctx = test.is(ctx, "addition", 1 + 1, 2);
-//   ctx = test.ok(ctx, "truthy", true);
-//   ctx = test.isnt(ctx, "not equal", 1, 2);
-//   test.done(ctx);
+//   test.new()
+//       |> test.plan(3)
+//       |> test.is("addition", 1 + 1, 2)
+//       |> test.ok("truthy", true)
+//       |> test.isnt("not equal", 1, 2)
+//       |> test.done();
 
 namespace test;
 

--- a/tests/array.test.ca
+++ b/tests/array.test.ca
@@ -4,76 +4,56 @@ use test;
 
 io.println("# Array Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 25);
-
-// === Basic Operations ===
-io.println("# Basic operations");
+// === Pre-compute values ===
 arr = [1, 2, 3, 4, 5];
-ctx = test.is(ctx, "array length", len(arr), 5);
-ctx = test.is(ctx, "head", head(arr), 1);
-ctx = test.is(ctx, "tail length", len(tail(arr)), 4);
-ctx = test.is(ctx, "head of tail", head(tail(arr)), 2);
-
-// === Index Access ===
-io.println("# Index access");
-ctx = test.is(ctx, "index 0", arr[0], 1);
-ctx = test.is(ctx, "index 2", arr[2], 3);
-ctx = test.is(ctx, "index 4", arr[4], 5);
-
-// === Push ===
-io.println("# Push");
 arr2 = push([1, 2], 3);
-ctx = test.is(ctx, "after push", len(arr2), 3);
-ctx = test.is(ctx, "pushed element", arr2[2], 3);
-
-// === Empty Array ===
-io.println("# Empty array");
 empty = [];
-ctx = test.is(ctx, "empty array", len(empty), 0);
-
-// === Nested Arrays ===
-io.println("# Nested arrays");
 nested = [[1, 2], [3, 4]];
-ctx = test.is(ctx, "nested length", len(nested), 2);
-ctx = test.is(ctx, "nested[0][0]", nested[0][0], 1);
-ctx = test.is(ctx, "nested[1][1]", nested[1][1], 4);
-
-// === Map ===
-io.println("# Map");
 doubled = map([1, 2, 3], x => x * 2);
-ctx = test.is(ctx, "map first", doubled[0], 2);
-ctx = test.is(ctx, "map second", doubled[1], 4);
-ctx = test.is(ctx, "map third", doubled[2], 6);
-
-// === Filter ===
-io.println("# Filter");
 evens = filter([1, 2, 3, 4, 5], x => x % 2 == 0);
-ctx = test.is(ctx, "filter count", len(evens), 2);
-ctx = test.is(ctx, "filter first", evens[0], 2);
-ctx = test.is(ctx, "filter second", evens[1], 4);
-
-// === Reduce ===
-io.println("# Reduce");
 sum = reduce([1, 2, 3, 4, 5], (acc, x) => acc + x, 0);
-ctx = test.is(ctx, "reduce sum", sum, 15);
-
 product = reduce([1, 2, 3, 4], (acc, x) => acc * x, 1);
-ctx = test.is(ctx, "reduce product", product, 24);
-
-// === Range ===
-io.println("# Range");
 r = range(1, 5);
-ctx = test.is(ctx, "range length", len(r), 4);
-ctx = test.is(ctx, "range first", r[0], 1);
-ctx = test.is(ctx, "range last", r[3], 4);
-
-// === Combination ===
-io.println("# Combination (map + filter + reduce)");
-result = range(1, 11)
+combo_result = range(1, 11)
     |> filter(x => x % 2 == 0)
     |> map(x => x * x)
     |> reduce((acc, x) => acc + x, 0);
-ctx = test.is(ctx, "sum of squared evens", result, 220);
 
-test.done(ctx);
+test.new()
+    |> test.plan(25)
+    // Basic Operations
+    |> test.is("array length", len(arr), 5)
+    |> test.is("head", head(arr), 1)
+    |> test.is("tail length", len(tail(arr)), 4)
+    |> test.is("head of tail", head(tail(arr)), 2)
+    // Index Access
+    |> test.is("index 0", arr[0], 1)
+    |> test.is("index 2", arr[2], 3)
+    |> test.is("index 4", arr[4], 5)
+    // Push
+    |> test.is("after push", len(arr2), 3)
+    |> test.is("pushed element", arr2[2], 3)
+    // Empty Array
+    |> test.is("empty array", len(empty), 0)
+    // Nested Arrays
+    |> test.is("nested length", len(nested), 2)
+    |> test.is("nested[0][0]", nested[0][0], 1)
+    |> test.is("nested[1][1]", nested[1][1], 4)
+    // Map
+    |> test.is("map first", doubled[0], 2)
+    |> test.is("map second", doubled[1], 4)
+    |> test.is("map third", doubled[2], 6)
+    // Filter
+    |> test.is("filter count", len(evens), 2)
+    |> test.is("filter first", evens[0], 2)
+    |> test.is("filter second", evens[1], 4)
+    // Reduce
+    |> test.is("reduce sum", sum, 15)
+    |> test.is("reduce product", product, 24)
+    // Range
+    |> test.is("range length", len(r), 4)
+    |> test.is("range first", r[0], 1)
+    |> test.is("range last", r[3], 4)
+    // Combination
+    |> test.is("sum of squared evens", combo_result, 220)
+    |> test.done();

--- a/tests/constraint.test.ca
+++ b/tests/constraint.test.ca
@@ -5,57 +5,23 @@ use core.string;
 
 io.println("# Constraint Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 31);
-
-// === Basic Constraint ===
-io.println("# Basic constraint");
+// === Define Constraints ===
 constraint Positive(x) = x > 0;
-ctx = test.ok(ctx, "5 is positive", Positive(5));
-ctx = test.ok(ctx, "5 passes Positive", Positive(5));
-ctx = test.is(ctx, "-3 fails Positive", Positive(-3), false);
-ctx = test.is(ctx, "0 fails Positive", Positive(0), false);
-
-// === String Constraint ===
-io.println("# String constraint");
 constraint NonEmpty(s) = len(s) > 0;
-ctx = test.ok(ctx, "hello is non-empty", NonEmpty("hello"));
-ctx = test.is(ctx, "empty fails NonEmpty", NonEmpty(""), false);
-
-// === Compound Constraint ===
-io.println("# Compound constraint");
 constraint InRange(x) = x >= 0 && x <= 100;
-ctx = test.ok(ctx, "50 in range", InRange(50));
-ctx = test.ok(ctx, "0 in range", InRange(0));
-ctx = test.ok(ctx, "100 in range", InRange(100));
-ctx = test.is(ctx, "-1 out of range", InRange(-1), false);
-ctx = test.is(ctx, "101 out of range", InRange(101), false);
-
-// === Constraint with Contains ===
-io.println("# Constraint with string.contains");
 constraint Digit(c) = string.contains("0123456789", c);
-ctx = test.ok(ctx, "5 is digit", Digit("5"));
-ctx = test.is(ctx, "a is not digit", Digit("a"), false);
-
 constraint Letter(c) = string.contains("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", c);
-ctx = test.ok(ctx, "a is letter", Letter("a"));
-ctx = test.ok(ctx, "Z is letter", Letter("Z"));
-ctx = test.is(ctx, "5 is not letter", Letter("5"), false);
+constraint Even(n) = n % 2 == 0;
+constraint Odd(n) = n % 2 == 1;
+constraint PositiveEven(x) = Positive(x) && Even(x);
 
-// === Constraint in Match ===
-// Note: Using Constraint(value) returns boolean, useful for match branching
-io.println("# Constraint in match");
+// === Helper Functions ===
 func classify_char(c) = match Digit(c)
     true => "digit"
     false => match Letter(c)
         true => "letter"
         false => "other";
 
-ctx = test.is(ctx, "classify 5", classify_char("5"), "digit");
-ctx = test.is(ctx, "classify a", classify_char("a"), "letter");
-ctx = test.is(ctx, "classify @", classify_char("@"), "other");
-
-// Alternative: Using !? for result handling
 func is_digit(c) = c |> Digit? !? { success(_) => true  failure(_) => false };
 func is_letter(c) = c |> Letter? !? { success(_) => true  failure(_) => false };
 func classify_with_result(c) = match is_digit(c)
@@ -63,34 +29,50 @@ func classify_with_result(c) = match is_digit(c)
     false => match is_letter(c)
         true => "letter"
         false => "other";
-ctx = test.is(ctx, "result classify 5", classify_with_result("5"), "digit");
-ctx = test.is(ctx, "result classify a", classify_with_result("a"), "letter");
-
-// === Multiple Constraints ===
-io.println("# Multiple constraints");
-constraint Even(n) = n % 2 == 0;
-constraint Odd(n) = n % 2 == 1;
-
-ctx = test.ok(ctx, "4 is even", Even(4));
-ctx = test.ok(ctx, "7 is odd", Odd(7));
-ctx = test.is(ctx, "7 is not even", Even(7), false);
 
 func describe_parity(n) = match Even(n)
     true => "even"
     false => "odd";
 
-ctx = test.is(ctx, "parity 4", describe_parity(4), "even");
-ctx = test.is(ctx, "parity 7", describe_parity(7), "odd");
-
-// === Constraint Composition ===
-io.println("# Constraint composition");
-constraint PositiveEven(x) = Positive(x) && Even(x);
-ctx = test.ok(ctx, "4 is positive and even", PositiveEven(4));
-ctx = test.is(ctx, "3 is not positive-even", PositiveEven(3), false);
-ctx = test.is(ctx, "-4 is not positive-even", PositiveEven(-4), false);
-
-// Composing with && on boolean constraint results
-ctx = test.ok(ctx, "4 passes both", Positive(4) && Even(4));
-ctx = test.is(ctx, "3 fails composition", Positive(3) && Even(3), false);
-
-test.done(ctx);
+test.new()
+    |> test.plan(31)
+    // Basic constraint
+    |> test.ok("5 is positive", Positive(5))
+    |> test.ok("5 passes Positive", Positive(5))
+    |> test.is("-3 fails Positive", Positive(-3), false)
+    |> test.is("0 fails Positive", Positive(0), false)
+    // String constraint
+    |> test.ok("hello is non-empty", NonEmpty("hello"))
+    |> test.is("empty fails NonEmpty", NonEmpty(""), false)
+    // Compound constraint
+    |> test.ok("50 in range", InRange(50))
+    |> test.ok("0 in range", InRange(0))
+    |> test.ok("100 in range", InRange(100))
+    |> test.is("-1 out of range", InRange(-1), false)
+    |> test.is("101 out of range", InRange(101), false)
+    // Constraint with string.contains
+    |> test.ok("5 is digit", Digit("5"))
+    |> test.is("a is not digit", Digit("a"), false)
+    |> test.ok("a is letter", Letter("a"))
+    |> test.ok("Z is letter", Letter("Z"))
+    |> test.is("5 is not letter", Letter("5"), false)
+    // Constraint in match
+    |> test.is("classify 5", classify_char("5"), "digit")
+    |> test.is("classify a", classify_char("a"), "letter")
+    |> test.is("classify @", classify_char("@"), "other")
+    // Alternative: Using !? for result handling
+    |> test.is("result classify 5", classify_with_result("5"), "digit")
+    |> test.is("result classify a", classify_with_result("a"), "letter")
+    // Multiple constraints
+    |> test.ok("4 is even", Even(4))
+    |> test.ok("7 is odd", Odd(7))
+    |> test.is("7 is not even", Even(7), false)
+    |> test.is("parity 4", describe_parity(4), "even")
+    |> test.is("parity 7", describe_parity(7), "odd")
+    // Constraint composition
+    |> test.ok("4 is positive and even", PositiveEven(4))
+    |> test.is("3 is not positive-even", PositiveEven(3), false)
+    |> test.is("-4 is not positive-even", PositiveEven(-4), false)
+    |> test.ok("4 passes both", Positive(4) && Even(4))
+    |> test.is("3 fails composition", Positive(3) && Even(3), false)
+    |> test.done();

--- a/tests/core.test.ca
+++ b/tests/core.test.ca
@@ -4,63 +4,55 @@ use test;
 
 io.println("# Core Language Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 22);
-
 // === Variables ===
-io.println("# Variables");
 x = 42;
-ctx = test.is(ctx, "simple assignment", x, 42);
 y = x + 8;
-ctx = test.is(ctx, "expression assignment", y, 50);
-
-// === Arithmetic ===
-io.println("# Arithmetic");
-ctx = test.is(ctx, "addition", 1 + 2, 3);
-ctx = test.is(ctx, "subtraction", 10 - 3, 7);
-ctx = test.is(ctx, "multiplication", 4 * 5, 20);
-ctx = test.is(ctx, "division", 15 / 3, 5);
-ctx = test.is(ctx, "modulo", 17 % 5, 2);
-ctx = test.is(ctx, "negation", -5, 0 - 5);
-
-// === Comparison ===
-io.println("# Comparison");
-ctx = test.ok(ctx, "less than", 1 < 2);
-ctx = test.ok(ctx, "less or equal", 2 <= 2);
-ctx = test.ok(ctx, "greater than", 3 > 2);
-ctx = test.ok(ctx, "greater or equal", 3 >= 3);
-ctx = test.ok(ctx, "equal", 5 == 5);
-ctx = test.ok(ctx, "not equal", 5 != 6);
-
-// === Boolean Logic ===
-io.println("# Boolean Logic");
-ctx = test.ok(ctx, "and true", true && true);
-ctx = test.is(ctx, "and false", true && false, false);
-ctx = test.ok(ctx, "or true", true || false);
-ctx = test.is(ctx, "or false", false || false, false);
 
 // === Functions ===
-io.println("# Functions");
 func add(a, b) = a + b;
-ctx = test.is(ctx, "function call", add(2, 3), 5);
-
 func factorial(n) = match n
     0 => 1
     _ => n * factorial(n - 1);
-ctx = test.is(ctx, "recursive factorial", factorial(5), 120);
 
 // === Closures ===
-io.println("# Closures");
 func make_adder(x) = y => x + y;
 add5 = make_adder(5);
-ctx = test.is(ctx, "closure call", add5(10), 15);
 
 // === Recursion ===
-io.println("# Recursion");
 func fib(n) = match n
     0 => 0
     1 => 1
     _ => fib(n - 1) + fib(n - 2);
-ctx = test.is(ctx, "fibonacci(10)", fib(10), 55);
 
-test.done(ctx);
+test.new()
+    |> test.plan(22)
+    // Variables
+    |> test.is("simple assignment", x, 42)
+    |> test.is("expression assignment", y, 50)
+    // Arithmetic
+    |> test.is("addition", 1 + 2, 3)
+    |> test.is("subtraction", 10 - 3, 7)
+    |> test.is("multiplication", 4 * 5, 20)
+    |> test.is("division", 15 / 3, 5)
+    |> test.is("modulo", 17 % 5, 2)
+    |> test.is("negation", -5, 0 - 5)
+    // Comparison
+    |> test.ok("less than", 1 < 2)
+    |> test.ok("less or equal", 2 <= 2)
+    |> test.ok("greater than", 3 > 2)
+    |> test.ok("greater or equal", 3 >= 3)
+    |> test.ok("equal", 5 == 5)
+    |> test.ok("not equal", 5 != 6)
+    // Boolean Logic
+    |> test.ok("and true", true && true)
+    |> test.is("and false", true && false, false)
+    |> test.ok("or true", true || false)
+    |> test.is("or false", false || false, false)
+    // Functions
+    |> test.is("function call", add(2, 3), 5)
+    |> test.is("recursive factorial", factorial(5), 120)
+    // Closures
+    |> test.is("closure call", add5(10), 15)
+    // Recursion
+    |> test.is("fibonacci(10)", fib(10), 55)
+    |> test.done();

--- a/tests/hash.test.ca
+++ b/tests/hash.test.ca
@@ -4,76 +4,23 @@ use test;
 
 io.println("# Hash Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 28);
-
 // Helper: check if array contains a value
 func arr_contains(arr, val) = len(filter(arr, x => x == val)) > 0;
 
-// === Basic Operations ===
-io.println("# Basic operations");
+// === Pre-compute values ===
 h = {a: 1, b: 2, c: 3};
-ctx = test.is(ctx, "dot access a", h.a, 1);
-ctx = test.is(ctx, "bracket access b", h["b"], 2);
-ctx = test.is(ctx, "dot access c", h.c, 3);
-
-// === Keys and Values ===
-io.println("# Keys and values");
-ctx = test.is(ctx, "keys count", len(keys(h)), 3);
-ctx = test.is(ctx, "values count", len(values(h)), 3);
-ctx = test.ok(ctx, "has key a", arr_contains(keys(h), "a"));
-ctx = test.ok(ctx, "has key b", arr_contains(keys(h), "b"));
-ctx = test.ok(ctx, "has value 1", arr_contains(values(h), 1));
-ctx = test.ok(ctx, "has value 2", arr_contains(values(h), 2));
-
-// === Empty Hash ===
-io.println("# Empty hash");
 empty = {};
-ctx = test.is(ctx, "empty keys", len(keys(empty)), 0);
-
-// === Nested Hash ===
-io.println("# Nested hash");
 nested = {
     outer: {
         inner: 42
     }
 };
-ctx = test.is(ctx, "nested dot access", nested.outer.inner, 42);
-ctx = test.is(ctx, "nested bracket access", nested["outer"]["inner"], 42);
-
-// === hash_set ===
-io.println("# hash_set");
 h1 = {a: 1};
 h2 = hash_set(h1, "b", 2);
-ctx = test.is(ctx, "original key", h2.a, 1);
-ctx = test.is(ctx, "added key", h2.b, 2);
-ctx = test.is(ctx, "keys after add", len(keys(h2)), 2);
-
-// hash_set replaces existing key
 h3 = hash_set(h2, "a", 100);
-ctx = test.is(ctx, "replaced key", h3.a, 100);
-ctx = test.is(ctx, "unchanged key", h3.b, 2);
-
-// === hash_merge ===
-io.println("# hash_merge");
 left = {a: 1, b: 2};
 right = {b: 20, c: 3};
 merged = hash_merge(left, right);
-ctx = test.is(ctx, "left only key", merged.a, 1);
-ctx = test.is(ctx, "overwritten key", merged.b, 20);
-ctx = test.is(ctx, "right only key", merged.c, 3);
-
-// === has ===
-io.println("# has");
-ctx = test.ok(ctx, "has existing key", has(h, "a"));
-ctx = test.is(ctx, "has missing key", has(h, "x"), false);
-
-// === get ===
-io.println("# get");
-ctx = test.is(ctx, "get existing", get(h, "a"), 1);
-
-// === Mixed Value Types ===
-io.println("# Mixed value types");
 mixed = {
     num: 42,
     str: "hello",
@@ -81,10 +28,44 @@ mixed = {
     arr: [1, 2, 3],
     nested: {x: 1}
 };
-ctx = test.is(ctx, "num value", mixed.num, 42);
-ctx = test.is(ctx, "str value", mixed.str, "hello");
-ctx = test.ok(ctx, "bool value", mixed.bool);
-ctx = test.is(ctx, "arr value", len(mixed.arr), 3);
-ctx = test.is(ctx, "nested value", mixed.nested.x, 1);
 
-test.done(ctx);
+test.new()
+    |> test.plan(28)
+    // Basic Operations
+    |> test.is("dot access a", h.a, 1)
+    |> test.is("bracket access b", h["b"], 2)
+    |> test.is("dot access c", h.c, 3)
+    // Keys and Values
+    |> test.is("keys count", len(keys(h)), 3)
+    |> test.is("values count", len(values(h)), 3)
+    |> test.ok("has key a", arr_contains(keys(h), "a"))
+    |> test.ok("has key b", arr_contains(keys(h), "b"))
+    |> test.ok("has value 1", arr_contains(values(h), 1))
+    |> test.ok("has value 2", arr_contains(values(h), 2))
+    // Empty Hash
+    |> test.is("empty keys", len(keys(empty)), 0)
+    // Nested Hash
+    |> test.is("nested dot access", nested.outer.inner, 42)
+    |> test.is("nested bracket access", nested["outer"]["inner"], 42)
+    // hash_set
+    |> test.is("original key", h2.a, 1)
+    |> test.is("added key", h2.b, 2)
+    |> test.is("keys after add", len(keys(h2)), 2)
+    |> test.is("replaced key", h3.a, 100)
+    |> test.is("unchanged key", h3.b, 2)
+    // hash_merge
+    |> test.is("left only key", merged.a, 1)
+    |> test.is("overwritten key", merged.b, 20)
+    |> test.is("right only key", merged.c, 3)
+    // has
+    |> test.ok("has existing key", has(h, "a"))
+    |> test.is("has missing key", has(h, "x"), false)
+    // get
+    |> test.is("get existing", get(h, "a"), 1)
+    // Mixed Value Types
+    |> test.is("num value", mixed.num, 42)
+    |> test.is("str value", mixed.str, "hello")
+    |> test.ok("bool value", mixed.bool)
+    |> test.is("arr value", len(mixed.arr), 3)
+    |> test.is("nested value", mixed.nested.x, 1)
+    |> test.done();

--- a/tests/json.test.ca
+++ b/tests/json.test.ca
@@ -5,196 +5,89 @@ use test;
 
 io.println("# core.json Module Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 30);
-
-// ============================================
-// parse: Numbers
-// ============================================
-
-io.println("# parse: Numbers");
-
-json.parse("42") !? {
-    success(v) => ctx = test.is(ctx, "parse integer", v, 42)
-    failure(e) => ctx = test.fail(ctx, "parse integer")
-};
-json.parse("-17") !? {
-    success(v) => ctx = test.is(ctx, "parse negative integer", v, -17)
-    failure(e) => ctx = test.fail(ctx, "parse negative integer")
-};
-json.parse("3.14") !? {
-    success(v) => ctx = test.is(ctx, "parse float", v, 3.14)
-    failure(e) => ctx = test.fail(ctx, "parse float")
-};
-json.parse("0") !? {
-    success(v) => ctx = test.is(ctx, "parse zero", v, 0)
-    failure(e) => ctx = test.fail(ctx, "parse zero")
+// === Helper ===
+func unwrap_or(result, default_val) = result !? {
+    success(v) => v
+    failure(_) => default_val
 };
 
-// ============================================
-// parse: Booleans and Null
-// ============================================
+// === Pre-compute parsed values ===
+p_int = unwrap_or(json.parse("42"), -999);
+p_neg = unwrap_or(json.parse("-17"), -999);
+p_float = unwrap_or(json.parse("3.14"), -999.0);
+p_zero = unwrap_or(json.parse("0"), -999);
+p_true = unwrap_or(json.parse("true"), -999);
+p_false = unwrap_or(json.parse("false"), -999);
+p_str = unwrap_or(json.parse('"hello"'), "");
+p_empty_str = unwrap_or(json.parse('""'), "FAIL");
+p_str_space = unwrap_or(json.parse('"hello world"'), "");
+p_empty_arr = unwrap_or(json.parse("[]"), []);
+p_arr = unwrap_or(json.parse("[1, 2, 3]"), []);
+p_arr2 = unwrap_or(json.parse("[1, 2, 3]"), []);
+p_obj = unwrap_or(json.parse('{"name": "Alice", "age": 30}'), {});
+p_obj2 = unwrap_or(json.parse('{"name": "Alice", "age": 30}'), {});
+p_nested = unwrap_or(json.parse('{"numbers": [1, 2, 3]}'), {});
+p_arr_obj = unwrap_or(json.parse('[{"id": 1}, {"id": 2}]'), []);
 
-io.println("# parse: Booleans and Null");
+// === Pre-compute stringified values ===
+s_int = unwrap_or(json.stringify(42), "");
+s_true = unwrap_or(json.stringify(true), "");
+s_false = unwrap_or(json.stringify(false), "");
+s_str = unwrap_or(json.stringify("hello"), "");
+s_empty_arr = unwrap_or(json.stringify([]), "");
+s_int_arr = unwrap_or(json.stringify([1, 2, 3]), "");
 
-json.parse("true") !? {
-    success(v) => ctx = test.is(ctx, "parse true", v, true)
-    failure(e) => ctx = test.fail(ctx, "parse true")
-};
-json.parse("false") !? {
-    success(v) => ctx = test.is(ctx, "parse false", v, false)
-    failure(e) => ctx = test.fail(ctx, "parse false")
-};
+// === Round-trip ===
+rt_int = unwrap_or(json.parse(unwrap_or(json.stringify(42), "")), -999);
+rt_arr = unwrap_or(json.parse(unwrap_or(json.stringify([1, 2, 3]), "")), []);
 
-// ============================================
-// parse: Strings
-// ============================================
+// === Error cases ===
+empty_fails = json.parse("") !? { success(_) => false  failure(_) => true };
+invalid_fails = json.parse("invalid") !? { success(_) => false  failure(_) => true };
 
-io.println("# parse: Strings");
+// === Aliases ===
+decode_val = unwrap_or(json.decode("42"), -999);
+encode_val = unwrap_or(json.encode(42), "");
 
-json.parse('"hello"') !? {
-    success(v) => ctx = test.is(ctx, "parse string", v, "hello")
-    failure(e) => ctx = test.fail(ctx, "parse string")
-};
-json.parse('""') !? {
-    success(v) => ctx = test.is(ctx, "parse empty string", v, "")
-    failure(e) => ctx = test.fail(ctx, "parse empty string")
-};
-json.parse('"hello world"') !? {
-    success(v) => ctx = test.is(ctx, "parse string with space", v, "hello world")
-    failure(e) => ctx = test.fail(ctx, "parse string with space")
-};
-
-// ============================================
-// parse: Arrays
-// ============================================
-
-io.println("# parse: Arrays");
-
-json.parse("[]") !? {
-    success(v) => ctx = test.is(ctx, "parse empty array length", len(v), 0)
-    failure(e) => ctx = test.fail(ctx, "parse empty array")
-};
-json.parse("[1, 2, 3]") !? {
-    success(v) => ctx = test.is(ctx, "parse array first", v[0], 1)
-    failure(e) => ctx = test.fail(ctx, "parse array first")
-};
-json.parse("[1, 2, 3]") !? {
-    success(v) => ctx = test.is(ctx, "parse array length", len(v), 3)
-    failure(e) => ctx = test.fail(ctx, "parse array length")
-};
-
-// ============================================
-// parse: Objects
-// ============================================
-
-io.println("# parse: Objects");
-
-json.parse('{"name": "Alice", "age": 30}') !? {
-    success(v) => ctx = test.is(ctx, "parse object string value", v["name"], "Alice")
-    failure(e) => ctx = test.fail(ctx, "parse object string value")
-};
-json.parse('{"name": "Alice", "age": 30}') !? {
-    success(v) => ctx = test.is(ctx, "parse object number value", v["age"], 30)
-    failure(e) => ctx = test.fail(ctx, "parse object number value")
-};
-
-// ============================================
-// parse: Nested structures
-// ============================================
-
-io.println("# parse: Nested structures");
-
-json.parse('{"numbers": [1, 2, 3]}') !? {
-    success(v) => ctx = test.is(ctx, "parse object with array length", len(v["numbers"]), 3)
-    failure(e) => ctx = test.fail(ctx, "parse object with array")
-};
-json.parse('[{"id": 1}, {"id": 2}]') !? {
-    success(v) => ctx = test.is(ctx, "parse array of objects", v[1]["id"], 2)
-    failure(e) => ctx = test.fail(ctx, "parse array of objects")
-};
-
-// ============================================
-// stringify: Primitives
-// ============================================
-
-io.println("# stringify: Primitives");
-
-json.stringify(42) !? {
-    success(v) => ctx = test.is(ctx, "stringify int", v, "42")
-    failure(e) => ctx = test.fail(ctx, "stringify int")
-};
-json.stringify(true) !? {
-    success(v) => ctx = test.is(ctx, "stringify true", v, "true")
-    failure(e) => ctx = test.fail(ctx, "stringify true")
-};
-json.stringify(false) !? {
-    success(v) => ctx = test.is(ctx, "stringify false", v, "false")
-    failure(e) => ctx = test.fail(ctx, "stringify false")
-};
-json.stringify("hello") !? {
-    success(v) => ctx = test.is(ctx, "stringify string", v, '"hello"')
-    failure(e) => ctx = test.fail(ctx, "stringify string")
-};
-
-// ============================================
-// stringify: Arrays
-// ============================================
-
-io.println("# stringify: Arrays");
-
-json.stringify([]) !? {
-    success(v) => ctx = test.is(ctx, "stringify empty array", v, "[]")
-    failure(e) => ctx = test.fail(ctx, "stringify empty array")
-};
-json.stringify([1, 2, 3]) !? {
-    success(v) => ctx = test.is(ctx, "stringify int array", v, "[1,2,3]")
-    failure(e) => ctx = test.fail(ctx, "stringify int array")
-};
-
-// ============================================
-// Round-trip
-// ============================================
-
-io.println("# Round-trip");
-
-json.parse(json.stringify(42) !? { success(v) => v failure(_) => "" }) !? {
-    success(v) => ctx = test.is(ctx, "round-trip integer", v, 42)
-    failure(e) => ctx = test.fail(ctx, "round-trip integer")
-};
-json.parse(json.stringify([1, 2, 3]) !? { success(v) => v failure(_) => "" }) !? {
-    success(v) => ctx = test.is(ctx, "round-trip array first", v[0], 1)
-    failure(e) => ctx = test.fail(ctx, "round-trip array")
-};
-
-// ============================================
-// Error cases
-// ============================================
-
-io.println("# Error cases");
-
-json.parse("") !? {
-    success(_) => ctx = test.fail(ctx, "empty input should fail")
-    failure(e) => ctx = test.pass(ctx, "empty input returns failure")
-};
-json.parse("invalid") !? {
-    success(_) => ctx = test.fail(ctx, "invalid input should fail")
-    failure(e) => ctx = test.pass(ctx, "invalid input returns failure")
-};
-
-// ============================================
-// Aliases
-// ============================================
-
-io.println("# Aliases");
-
-json.decode("42") !? {
-    success(v) => ctx = test.is(ctx, "decode alias", v, 42)
-    failure(e) => ctx = test.fail(ctx, "decode alias")
-};
-json.encode(42) !? {
-    success(v) => ctx = test.is(ctx, "encode alias", v, "42")
-    failure(e) => ctx = test.fail(ctx, "encode alias")
-};
-
-test.done(ctx);
+test.new()
+    |> test.plan(30)
+    // parse: Numbers
+    |> test.is("parse integer", p_int, 42)
+    |> test.is("parse negative integer", p_neg, -17)
+    |> test.is("parse float", p_float, 3.14)
+    |> test.is("parse zero", p_zero, 0)
+    // parse: Booleans
+    |> test.is("parse true", p_true, true)
+    |> test.is("parse false", p_false, false)
+    // parse: Strings
+    |> test.is("parse string", p_str, "hello")
+    |> test.is("parse empty string", p_empty_str, "")
+    |> test.is("parse string with space", p_str_space, "hello world")
+    // parse: Arrays
+    |> test.is("parse empty array length", len(p_empty_arr), 0)
+    |> test.is("parse array first", p_arr[0], 1)
+    |> test.is("parse array length", len(p_arr2), 3)
+    // parse: Objects
+    |> test.is("parse object string value", p_obj["name"], "Alice")
+    |> test.is("parse object number value", p_obj2["age"], 30)
+    // parse: Nested structures
+    |> test.is("parse object with array length", len(p_nested["numbers"]), 3)
+    |> test.is("parse array of objects", p_arr_obj[1]["id"], 2)
+    // stringify: Primitives
+    |> test.is("stringify int", s_int, "42")
+    |> test.is("stringify true", s_true, "true")
+    |> test.is("stringify false", s_false, "false")
+    |> test.is("stringify string", s_str, '"hello"')
+    // stringify: Arrays
+    |> test.is("stringify empty array", s_empty_arr, "[]")
+    |> test.is("stringify int array", s_int_arr, "[1,2,3]")
+    // Round-trip
+    |> test.is("round-trip integer", rt_int, 42)
+    |> test.is("round-trip array first", rt_arr[0], 1)
+    // Error cases
+    |> test.ok("empty input returns failure", empty_fails)
+    |> test.ok("invalid input returns failure", invalid_fails)
+    // Aliases
+    |> test.is("decode alias", decode_val, 42)
+    |> test.is("encode alias", encode_val, "42")
+    |> test.done();

--- a/tests/match.test.ca
+++ b/tests/match.test.ca
@@ -4,62 +4,34 @@ use test;
 
 io.println("# Pattern Matching Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 18);
-
 // === Literal Matching ===
-io.println("# Literal matching");
 func describe_num(n) = match n
     0 => "zero"
     1 => "one"
     2 => "two"
     _ => "many";
 
-ctx = test.is(ctx, "match 0", describe_num(0), "zero");
-ctx = test.is(ctx, "match 1", describe_num(1), "one");
-ctx = test.is(ctx, "match 2", describe_num(2), "two");
-ctx = test.is(ctx, "match wildcard", describe_num(100), "many");
-
 // === Boolean Matching ===
-io.println("# Boolean matching");
 func bool_to_str(b) = match b
     true => "yes"
     false => "no";
 
-ctx = test.is(ctx, "match true", bool_to_str(true), "yes");
-ctx = test.is(ctx, "match false", bool_to_str(false), "no");
-
 // === String Matching ===
-io.println("# String matching");
 func greet(name) = match name
     "Alice" => "Hello, Alice!"
     "Bob" => "Hi, Bob!"
     _ => concat("Welcome, ", name);
 
-ctx = test.is(ctx, "match Alice", greet("Alice"), "Hello, Alice!");
-ctx = test.is(ctx, "match Bob", greet("Bob"), "Hi, Bob!");
-ctx = test.is(ctx, "match other", greet("Charlie"), "Welcome, Charlie");
-
 // === Wildcard ===
-io.println("# Wildcard");
 func always_default(x) = match x
     _ => "default";
 
-ctx = test.is(ctx, "wildcard int", always_default(1), "default");
-ctx = test.is(ctx, "wildcard string", always_default("hello"), "default");
-ctx = test.is(ctx, "wildcard bool", always_default(true), "default");
-
 // === Recursive Pattern Matching ===
-io.println("# Recursive with match");
 func sum_list(lst) = match len(lst)
     0 => 0
     _ => head(lst) + sum_list(tail(lst));
 
-ctx = test.is(ctx, "sum empty list", sum_list([]), 0);
-ctx = test.is(ctx, "sum [1..5]", sum_list([1, 2, 3, 4, 5]), 15);
-
 // === Nested Match ===
-io.println("# Nested match");
 func classify_positive(x) = match x > 100
     true => "large positive"
     false => "small positive";
@@ -72,9 +44,30 @@ func classify(x) = match x > 0
     true => classify_positive(x)
     false => classify_non_positive(x);
 
-ctx = test.is(ctx, "classify 500", classify(500), "large positive");
-ctx = test.is(ctx, "classify 50", classify(50), "small positive");
-ctx = test.is(ctx, "classify 0", classify(0), "zero");
-ctx = test.is(ctx, "classify -10", classify(-10), "negative");
-
-test.done(ctx);
+test.new()
+    |> test.plan(18)
+    // Literal matching
+    |> test.is("match 0", describe_num(0), "zero")
+    |> test.is("match 1", describe_num(1), "one")
+    |> test.is("match 2", describe_num(2), "two")
+    |> test.is("match wildcard", describe_num(100), "many")
+    // Boolean matching
+    |> test.is("match true", bool_to_str(true), "yes")
+    |> test.is("match false", bool_to_str(false), "no")
+    // String matching
+    |> test.is("match Alice", greet("Alice"), "Hello, Alice!")
+    |> test.is("match Bob", greet("Bob"), "Hi, Bob!")
+    |> test.is("match other", greet("Charlie"), "Welcome, Charlie")
+    // Wildcard
+    |> test.is("wildcard int", always_default(1), "default")
+    |> test.is("wildcard string", always_default("hello"), "default")
+    |> test.is("wildcard bool", always_default(true), "default")
+    // Recursive with match
+    |> test.is("sum empty list", sum_list([]), 0)
+    |> test.is("sum [1..5]", sum_list([1, 2, 3, 4, 5]), 15)
+    // Nested match
+    |> test.is("classify 500", classify(500), "large positive")
+    |> test.is("classify 50", classify(50), "small positive")
+    |> test.is("classify 0", classify(0), "zero")
+    |> test.is("classify -10", classify(-10), "negative")
+    |> test.done();

--- a/tests/pipeline.test.ca
+++ b/tests/pipeline.test.ca
@@ -1,69 +1,57 @@
 // Pipeline Operator Test
 use core.io!;
 use test;
+use core.string;
 
 io.println("# Pipeline Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 10);
-
-// === Basic Pipeline ===
-io.println("# Basic pipeline");
-result = 5 |> (x => x * 2);
-ctx = test.is(ctx, "simple pipe", result, 10);
-
-// === Chained Pipeline ===
-io.println("# Chained pipeline");
-result2 = 5
-    |> (x => x * 2)
-    |> (x => x + 3)
-    |> (x => x * x);
-ctx = test.is(ctx, "chained transforms", result2, 169);
-
-// === Pipeline with Named Functions ===
-io.println("# Pipeline with named functions");
+// === Named Functions ===
 func double(x) = x * 2;
 func add_ten(x) = x + 10;
 func square(x) = x * x;
 
+// === Pre-compute values ===
+result = 5 |> (x => x * 2);
+result2 = 5
+    |> (x => x * 2)
+    |> (x => x + 3)
+    |> (x => x * x);
 result3 = 3 |> double |> add_ten |> square;
-ctx = test.is(ctx, "named functions", result3, 256);
-
-// === Pipeline with Arrays ===
-io.println("# Pipeline with arrays");
 nums = [1, 2, 3, 4, 5];
 sum_of_squares = nums
     |> map(x => x * x)
     |> reduce((acc, x) => acc + x, 0);
-ctx = test.is(ctx, "sum of squares", sum_of_squares, 55);
-
-// === Pipeline with Filter ===
-io.println("# Pipeline with filter");
 evens_doubled = [1, 2, 3, 4, 5, 6]
     |> filter(x => x % 2 == 0)
     |> map(x => x * 2);
-ctx = test.is(ctx, "filtered length", len(evens_doubled), 3);
-ctx = test.is(ctx, "first doubled even", evens_doubled[0], 4);
-ctx = test.is(ctx, "second doubled even", evens_doubled[1], 8);
-ctx = test.is(ctx, "third doubled even", evens_doubled[2], 12);
-
-// === Complex Pipeline ===
-io.println("# Complex pipeline");
 result4 = range(1, 101)
     |> filter(x => x % 3 == 0)
     |> filter(x => x % 5 == 0)
     |> map(x => x / 15)
     |> reduce((acc, x) => acc + x, 0);
-ctx = test.is(ctx, "multiples of 15", result4, 21);
-
-// === Pipeline with String ===
-io.println("# Pipeline with string operations");
-use core.string;
 text = "  HELLO WORLD  ";
 processed = text
     |> string.trim
     |> string.to_lower
     |> string.replace("world", "calcium");
-ctx = test.is(ctx, "string pipeline", processed, "hello calcium");
 
-test.done(ctx);
+test.new()
+    |> test.plan(10)
+    // Basic pipeline
+    |> test.is("simple pipe", result, 10)
+    // Chained pipeline
+    |> test.is("chained transforms", result2, 169)
+    // Named functions
+    |> test.is("named functions", result3, 256)
+    // Pipeline with arrays
+    |> test.is("sum of squares", sum_of_squares, 55)
+    // Pipeline with filter
+    |> test.is("filtered length", len(evens_doubled), 3)
+    |> test.is("first doubled even", evens_doubled[0], 4)
+    |> test.is("second doubled even", evens_doubled[1], 8)
+    |> test.is("third doubled even", evens_doubled[2], 12)
+    // Complex pipeline
+    |> test.is("multiples of 15", result4, 21)
+    // Pipeline with string
+    |> test.is("string pipeline", processed, "hello calcium")
+    |> test.done();

--- a/tests/result.test.ca
+++ b/tests/result.test.ca
@@ -5,89 +5,33 @@ use core.types;
 
 io.println("# Result Handling Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 13);
-
-// === Success/Failure Creation ===
-io.println("# Success/Failure creation");
-s = success(42);
-f = failure("error");
-ctx = test.is(ctx, "success type", types.type_of(s), "success");
-ctx = test.is(ctx, "failure type", types.type_of(f), "failure");
-
-// === Basic !? Handling ===
-io.println("# Basic !? handling");
-result1 = success(42) !? {
+// === Helper ===
+func unwrap_or(result, default_val) = result !? {
     success(v) => v
-    failure(err) => 0
+    failure(_) => default_val
 };
-ctx = test.is(ctx, "unwrap success", result1, 42);
-
-result2 = failure("error") !? {
-    success(v) => v
-    failure(err) => 0
-};
-ctx = test.is(ctx, "unwrap failure", result2, 0);
 
 // === Effect Functions ===
-io.println("# Effect functions returning results");
 func safe_divide(a, b) = match b == 0
     true => failure("division by zero")
     false => success(a / b);
 
-ctx = safe_divide(10, 2) !? {
-    success(v) => test.is(ctx, "divide success", v, 5)
-    failure(err) => test.fail(ctx, "should not fail")
-};
-
-ctx = safe_divide(10, 0) !? {
-    success(v) => test.fail(ctx, "should fail")
-    failure(e) => test.is(ctx, "divide by zero error", e, "division by zero")
-};
-
-// === Result Unwrapping Helper ===
-io.println("# Result unwrapping");
-func unwrap_or(result, default_val) = result !? {
-    success(v) => v
-    failure(err) => default_val
-};
-
-ctx = test.is(ctx, "unwrap_or success", unwrap_or(success(42), 0), 42);
-ctx = test.is(ctx, "unwrap_or failure", unwrap_or(failure("error"), 0), 0);
-
-// === Simple Chaining ===
-io.println("# Simple chaining");
-func add_one(x) = success(x + 1);
-
-chain_result = add_one(1);
-v1 = unwrap_or(chain_result, 0);
-chain_result2 = add_one(v1);
-v2 = unwrap_or(chain_result2, 0);
-ctx = test.is(ctx, "chained result", v2, 3);
-
-// === Result in Function Body ===
-io.println("# Result in function body");
 func safe_sqrt(x) = match x >= 0
     true => success(x)
     false => failure("negative number");
 
 func process(x) = safe_sqrt(x) !? {
     success(v) => v * 2
-    failure(err) => -1
+    failure(_) => -1
 };
 
-ctx = test.is(ctx, "process positive", process(16), 32);
-ctx = test.is(ctx, "process negative", process(-4), -1);
-
 // === Step Functions for Pipeline ===
-io.println("# Propagating failures");
 func step1(x) = success(x + 10);
 func step2(x) = match x > 50
     true => failure("too large")
     false => success(x * 2);
 func step3(x) = success(x - 5);
 
-// Helper to chain steps
 func chain_step1(x) = step1(x);
 func chain_step2(r) = r !? {
     success(v) => step2(v)
@@ -97,18 +41,54 @@ func chain_step3(r) = r !? {
     success(v) => step3(v)
     failure(e) => failure(e)
 };
-
-// Pipeline using helper functions
 func run_pipeline(x) = chain_step3(chain_step2(chain_step1(x)));
 
-ctx = run_pipeline(10) !? {
-    success(v) => test.is(ctx, "pipeline success", v, 35)
-    failure(err) => test.fail(ctx, "should succeed")
+// === Pre-compute values ===
+result1 = success(42) !? {
+    success(v) => v
+    failure(_) => 0
+};
+result2 = failure("error") !? {
+    success(v) => v
+    failure(_) => 0
+};
+divide_ok = unwrap_or(safe_divide(10, 2), -1);
+divide_err = safe_divide(10, 0) !? {
+    success(_) => "unexpected"
+    failure(e) => e
+};
+func add_one(x) = success(x + 1);
+chain_result = add_one(1);
+v1 = unwrap_or(chain_result, 0);
+chain_result2 = add_one(v1);
+v2 = unwrap_or(chain_result2, 0);
+
+pipeline_ok = unwrap_or(run_pipeline(10), -1);
+pipeline_err = run_pipeline(50) !? {
+    success(_) => "unexpected"
+    failure(e) => e
 };
 
-ctx = run_pipeline(50) !? {
-    success(v) => test.fail(ctx, "should fail")
-    failure(e) => test.is(ctx, "pipeline failure", e, "too large")
-};
-
-test.done(ctx);
+test.new()
+    |> test.plan(13)
+    // Success/Failure Creation
+    |> test.is("success type", types.type_of(success(42)), "success")
+    |> test.is("failure type", types.type_of(failure("error")), "failure")
+    // Basic !? Handling
+    |> test.is("unwrap success", result1, 42)
+    |> test.is("unwrap failure", result2, 0)
+    // Effect Functions
+    |> test.is("divide success", divide_ok, 5)
+    |> test.is("divide by zero error", divide_err, "division by zero")
+    // Result Unwrapping
+    |> test.is("unwrap_or success", unwrap_or(success(42), 0), 42)
+    |> test.is("unwrap_or failure", unwrap_or(failure("error"), 0), 0)
+    // Simple Chaining
+    |> test.is("chained result", v2, 3)
+    // Result in Function Body
+    |> test.is("process positive", process(16), 32)
+    |> test.is("process negative", process(-4), -1)
+    // Propagating failures
+    |> test.is("pipeline success", pipeline_ok, 35)
+    |> test.is("pipeline failure", pipeline_err, "too large")
+    |> test.done();

--- a/tests/string.test.ca
+++ b/tests/string.test.ca
@@ -5,86 +5,69 @@ use core.string;
 
 io.println("# String Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 42);
-
-// === Basic Operations ===
-io.println("# Basic operations");
-ctx = test.is(ctx, "len hello", len("hello"), 5);
-ctx = test.is(ctx, "len empty", len(""), 0);
-ctx = test.is(ctx, "concat", concat("hello", " world"), "hello world");
-
-// === Character Access ===
-io.println("# Character access");
-ctx = test.is(ctx, "char_at first", string.char_at("hello", 0), "h");
-ctx = test.is(ctx, "char_at last", string.char_at("hello", 4), "o");
-
-// === Substring ===
-io.println("# Substring");
-ctx = test.is(ctx, "substring first word", string.substring("hello world", 0, 5), "hello");
-ctx = test.is(ctx, "substring second word", string.substring("hello world", 6, 11), "world");
-
-// === Search ===
-io.println("# Search");
-ctx = test.is(ctx, "index_of found", string.index_of("hello", "l"), 2);
-ctx = test.is(ctx, "index_of not found", string.index_of("hello", "x"), -1);
-ctx = test.ok(ctx, "contains positive", string.contains("hello world", "world"));
-ctx = test.is(ctx, "contains negative", string.contains("hello", "x"), false);
-ctx = test.ok(ctx, "starts_with positive", string.starts_with("hello", "he"));
-ctx = test.is(ctx, "starts_with negative", string.starts_with("hello", "lo"), false);
-ctx = test.ok(ctx, "ends_with positive", string.ends_with("hello", "lo"));
-ctx = test.is(ctx, "ends_with negative", string.ends_with("hello", "he"), false);
-
-// === Transformation ===
-io.println("# Transformation");
-ctx = test.is(ctx, "to_upper", string.to_upper("hello"), "HELLO");
-ctx = test.is(ctx, "to_lower", string.to_lower("HELLO"), "hello");
-ctx = test.is(ctx, "trim", string.trim("  hello  "), "hello");
-ctx = test.is(ctx, "replace", string.replace("hello world", "world", "calcium"), "hello calcium");
-
-// === Split and Join ===
-io.println("# Split and Join");
+// === Pre-compute values ===
 parts = string.split("a,b,c", ",");
-ctx = test.is(ctx, "split length", len(parts), 3);
-ctx = test.is(ctx, "split first", head(parts), "a");
-ctx = test.is(ctx, "join", string.join(["a", "b", "c"], "-"), "a-b-c");
-
-// === Escape Sequences ===
-io.println("# Escape sequences");
-ctx = test.is(ctx, "newline length", len("\n"), 1);
-ctx = test.is(ctx, "tab length", len("\t"), 1);
-ctx = test.is(ctx, "quote length", len("\""), 1);
-ctx = test.is(ctx, "backslash length", len("\\"), 1);
-
-// === Single-quoted Strings ===
-io.println("# Single-quoted strings");
-ctx = test.is(ctx, "single quote basic", 'hello', "hello");
-ctx = test.is(ctx, "single quote with spaces", 'hello world', "hello world");
-ctx = test.is(ctx, "single quote empty", '', "");
-ctx = test.is(ctx, "single quote length", len('hello'), 5);
-ctx = test.is(ctx, "single quote concat", concat('hello', ' world'), "hello world");
-ctx = test.is(ctx, "single quote double inside", 'say "hello"', "say \"hello\"");
-ctx = test.is(ctx, "single quote escape", 'it\'s', "it's");
-ctx = test.is(ctx, "single quote newline", len('\n'), 1);
-ctx = test.is(ctx, "single quote tab", len('\t'), 1);
-ctx = test.is(ctx, "single quote backslash", len('\\'), 1);
-
-// === Heredoc (Triple-quoted Strings) ===
-io.println("# Heredoc strings");
-ctx = test.is(ctx, "heredoc basic", """hello""", "hello");
-ctx = test.is(ctx, "heredoc with quotes", """say "hello" and 'hi'""", "say \"hello\" and 'hi'");
 multiline = """
 line 1
 line 2
 line 3
 """;
-ctx = test.is(ctx, "heredoc multiline", string.contains(multiline, "line 2"), true);
 lines = string.split(multiline, "\n");
-ctx = test.is(ctx, "heredoc line count", len(lines), 3);
-ctx = test.is(ctx, "heredoc first line", lines[0], "line 1");
 json_heredoc = """
 {"name": "test", "value": 42}
 """;
-ctx = test.ok(ctx, "heredoc json contains name", string.contains(json_heredoc, '"name"'));
 
-test.done(ctx);
+test.new()
+    |> test.plan(42)
+    // Basic Operations
+    |> test.is("len hello", len("hello"), 5)
+    |> test.is("len empty", len(""), 0)
+    |> test.is("concat", concat("hello", " world"), "hello world")
+    // Character Access
+    |> test.is("char_at first", string.char_at("hello", 0), "h")
+    |> test.is("char_at last", string.char_at("hello", 4), "o")
+    // Substring
+    |> test.is("substring first word", string.substring("hello world", 0, 5), "hello")
+    |> test.is("substring second word", string.substring("hello world", 6, 11), "world")
+    // Search
+    |> test.is("index_of found", string.index_of("hello", "l"), 2)
+    |> test.is("index_of not found", string.index_of("hello", "x"), -1)
+    |> test.ok("contains positive", string.contains("hello world", "world"))
+    |> test.is("contains negative", string.contains("hello", "x"), false)
+    |> test.ok("starts_with positive", string.starts_with("hello", "he"))
+    |> test.is("starts_with negative", string.starts_with("hello", "lo"), false)
+    |> test.ok("ends_with positive", string.ends_with("hello", "lo"))
+    |> test.is("ends_with negative", string.ends_with("hello", "he"), false)
+    // Transformation
+    |> test.is("to_upper", string.to_upper("hello"), "HELLO")
+    |> test.is("to_lower", string.to_lower("HELLO"), "hello")
+    |> test.is("trim", string.trim("  hello  "), "hello")
+    |> test.is("replace", string.replace("hello world", "world", "calcium"), "hello calcium")
+    // Split and Join
+    |> test.is("split length", len(parts), 3)
+    |> test.is("split first", head(parts), "a")
+    |> test.is("join", string.join(["a", "b", "c"], "-"), "a-b-c")
+    // Escape Sequences
+    |> test.is("newline length", len("\n"), 1)
+    |> test.is("tab length", len("\t"), 1)
+    |> test.is("quote length", len("\""), 1)
+    |> test.is("backslash length", len("\\"), 1)
+    // Single-quoted Strings
+    |> test.is("single quote basic", 'hello', "hello")
+    |> test.is("single quote with spaces", 'hello world', "hello world")
+    |> test.is("single quote empty", '', "")
+    |> test.is("single quote length", len('hello'), 5)
+    |> test.is("single quote concat", concat('hello', ' world'), "hello world")
+    |> test.is("single quote double inside", 'say "hello"', "say \"hello\"")
+    |> test.is("single quote escape", 'it\'s', "it's")
+    |> test.is("single quote newline", len('\n'), 1)
+    |> test.is("single quote tab", len('\t'), 1)
+    |> test.is("single quote backslash", len('\\'), 1)
+    // Heredoc (Triple-quoted Strings)
+    |> test.is("heredoc basic", """hello""", "hello")
+    |> test.is("heredoc with quotes", """say "hello" and 'hi'""", "say \"hello\" and 'hi'")
+    |> test.is("heredoc multiline", string.contains(multiline, "line 2"), true)
+    |> test.is("heredoc line count", len(lines), 3)
+    |> test.is("heredoc first line", lines[0], "line 1")
+    |> test.ok("heredoc json contains name", string.contains(json_heredoc, '"name"'))
+    |> test.done();

--- a/tests/types.test.ca
+++ b/tests/types.test.ca
@@ -5,68 +5,59 @@ use core.types;
 
 io.println("# Type System Tests");
 
-ctx = test.new();
-ctx = test.plan(ctx, 26);
-
-// === Type Detection ===
-io.println("# type_of");
-ctx = test.is(ctx, "int type", types.type_of(42), "int");
-ctx = test.is(ctx, "float type", types.type_of(3.14), "float");
-ctx = test.is(ctx, "string type", types.type_of("hello"), "string");
-ctx = test.is(ctx, "bool true type", types.type_of(true), "bool");
-ctx = test.is(ctx, "bool false type", types.type_of(false), "bool");
-ctx = test.is(ctx, "array type", types.type_of([1, 2, 3]), "array");
-ctx = test.is(ctx, "hash type", types.type_of({a: 1}), "hash");
-ctx = test.is(ctx, "null type", types.type_of(types.null), "null");
-
-// === Type Predicates ===
-io.println("# Type predicates");
-ctx = test.ok(ctx, "is_int positive", types.is_int(42));
-ctx = test.is(ctx, "is_int negative", types.is_int(3.14), false);
-ctx = test.ok(ctx, "is_float", types.is_float(3.14));
-ctx = test.ok(ctx, "is_string", types.is_string("hello"));
-ctx = test.ok(ctx, "is_bool", types.is_bool(true));
-ctx = test.ok(ctx, "is_array", types.is_array([1, 2]));
-ctx = test.ok(ctx, "is_hash", types.is_hash({a: 1}));
-ctx = test.ok(ctx, "is_null", types.is_null(types.null));
-ctx = test.ok(ctx, "is_number int", types.is_number(42));
-ctx = test.ok(ctx, "is_number float", types.is_number(3.14));
-ctx = test.is(ctx, "is_number string", types.is_number("42"), false);
-
-// === Type Conversion ===
-io.println("# to_int");
-ctx = types.to_int("42") !? {
-    success(v) => test.is(ctx, "from string", v, 42)
-    failure(e) => test.fail(ctx, "to_int from string failed")
-};
-ctx = types.to_int(3.7) !? {
-    success(v) => test.is(ctx, "from float", v, 3)
-    failure(e) => test.fail(ctx, "to_int from float failed")
-};
-ctx = types.to_int(true) !? {
-    success(v) => test.is(ctx, "from bool", v, 1)
-    failure(e) => test.fail(ctx, "to_int from bool failed")
+// === Pre-compute conversion results ===
+func unwrap_or(result, default_val) = result !? {
+    success(v) => v
+    failure(_) => default_val
 };
 
-io.println("# to_float");
-ctx = types.to_float("3.14") !? {
-    success(v) => test.is(ctx, "from string", v, 3.14)
-    failure(e) => test.fail(ctx, "to_float from string failed")
+to_int_str = unwrap_or(types.to_int("42"), -999);
+to_int_float = unwrap_or(types.to_int(3.7), -999);
+to_int_bool = unwrap_or(types.to_int(true), -999);
+to_float_str = unwrap_or(types.to_float("3.14"), -999.0);
+to_float_int = unwrap_or(types.to_float(42), -999.0);
+
+// Conversion error checks (should fail)
+to_int_invalid_is_failure = types.to_int("not a number") !? {
+    success(_) => false
+    failure(_) => true
 };
-ctx = types.to_float(42) !? {
-    success(v) => test.is(ctx, "from int", v, 42.0)
-    failure(e) => test.fail(ctx, "to_float from int failed")
+to_float_invalid_is_failure = types.to_float("not a number") !? {
+    success(_) => false
+    failure(_) => true
 };
 
-// === Conversion Errors ===
-io.println("# Conversion errors");
-ctx = types.to_int("not a number") !? {
-    success(v) => test.fail(ctx, "to_int invalid")
-    failure(e) => test.pass(ctx, "to_int invalid")
-};
-ctx = types.to_float("not a number") !? {
-    success(v) => test.fail(ctx, "to_float invalid")
-    failure(e) => test.pass(ctx, "to_float invalid")
-};
-
-test.done(ctx);
+test.new()
+    |> test.plan(26)
+    // Type Detection
+    |> test.is("int type", types.type_of(42), "int")
+    |> test.is("float type", types.type_of(3.14), "float")
+    |> test.is("string type", types.type_of("hello"), "string")
+    |> test.is("bool true type", types.type_of(true), "bool")
+    |> test.is("bool false type", types.type_of(false), "bool")
+    |> test.is("array type", types.type_of([1, 2, 3]), "array")
+    |> test.is("hash type", types.type_of({a: 1}), "hash")
+    |> test.is("null type", types.type_of(types.null), "null")
+    // Type Predicates
+    |> test.ok("is_int positive", types.is_int(42))
+    |> test.is("is_int negative", types.is_int(3.14), false)
+    |> test.ok("is_float", types.is_float(3.14))
+    |> test.ok("is_string", types.is_string("hello"))
+    |> test.ok("is_bool", types.is_bool(true))
+    |> test.ok("is_array", types.is_array([1, 2]))
+    |> test.ok("is_hash", types.is_hash({a: 1}))
+    |> test.ok("is_null", types.is_null(types.null))
+    |> test.ok("is_number int", types.is_number(42))
+    |> test.ok("is_number float", types.is_number(3.14))
+    |> test.is("is_number string", types.is_number("42"), false)
+    // Type Conversion: to_int
+    |> test.is("from string", to_int_str, 42)
+    |> test.is("from float", to_int_float, 3)
+    |> test.is("from bool", to_int_bool, 1)
+    // Type Conversion: to_float
+    |> test.is("from string", to_float_str, 3.14)
+    |> test.is("from int", to_float_int, 42.0)
+    // Conversion Errors
+    |> test.ok("to_int invalid", to_int_invalid_is_failure)
+    |> test.ok("to_float invalid", to_float_invalid_is_failure)
+    |> test.done();


### PR DESCRIPTION
## Summary

- Rewrote all 11 test files to use pipeline chaining style (`test.new() |> test.plan(N) |> test.is(...) |> test.done()`) instead of `ctx` reassignment pattern
- Pre-computed test values before pipeline chains to separate setup from assertions
- Net reduction of 237 lines (460 additions, 697 deletions) through more concise test syntax
- No changes to the test module API itself — `ctx` remains the first parameter for pipeline compatibility

## Context

This is a prerequisite for gh-69 (variable reassignment rejection). By eliminating `ctx = test.is(ctx, ...)` reassignment patterns in all test files, we can safely implement reassignment prohibition without breaking the test suite.

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] All 23 Calcium test files pass (`calcium test`)
- [x] 0 failures across all test suites

**Note:** Engineer and orchestrator were unresponsive after 3 TEAM_CREATE requests. superintendent performed direct implementation as fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)