### PR TITLE
gh-59: add core.os module for environment variables and process control

### DIFF
--- a/pkg/vm/primitives.go
+++ b/pkg/vm/primitives.go
@@ -1330,6 +1330,35 @@ func primitiveEnvList(args ...value.Value) value.Value {
 }
 
 // =============================================================================
+// OS / Process Primitives
+// =============================================================================
+
+// __os_args returns the command-line arguments as an array of strings
+func primitiveOsArgs(args ...value.Value) value.Value {
+	if len(args) != 0 {
+		return value.Failure(value.String("__os_args: expected 0 arguments"))
+	}
+
+	result := make([]value.Value, len(os.Args))
+	for i, a := range os.Args {
+		result[i] = value.String(a)
+	}
+	return value.Array(result)
+}
+
+// __os_exit terminates the process with the given exit code
+func primitiveOsExit(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__os_exit: expected 1 argument (code)"))
+	}
+	if args[0].Type != value.TYPE_INT {
+		return value.Failure(value.String("__os_exit: code must be integer"))
+	}
+	os.Exit(int(args[0].AsInt()))
+	return value.Null() // unreachable
+}
+
+// =============================================================================
 // Primitive Registry
 // =============================================================================
 
@@ -1416,5 +1445,9 @@ func GetPrimitives() map[string]*value.Builtin {
 		"__env_set":   {Name: "__env_set", Fn: primitiveEnvSet},
 		"__env_unset": {Name: "__env_unset", Fn: primitiveEnvUnset},
 		"__env_list":  {Name: "__env_list", Fn: primitiveEnvList},
+
+		// OS / Process
+		"__os_args": {Name: "__os_args", Fn: primitiveOsArgs},
+		"__os_exit": {Name: "__os_exit", Fn: primitiveOsExit},
 	}
 }

--- a/pkg/vm/stdlib/core/os.ca
+++ b/pkg/vm/stdlib/core/os.ca
@@ -1,0 +1,25 @@
+// core.os - Operating system and process interface
+// Uses primitives: __env_get, __env_set, __env_unset, __env_list, __os_args, __os_exit
+
+// env(name) - Get an environment variable by name
+// Returns success(value) if the variable is set, or failure(error) if not set
+func env(name) = __env_get(name);
+
+// set_env(name, value) - Set an environment variable
+// Returns success(null) or failure(error)
+func! set_env(name, val) = __env_set(name, val);
+
+// unset_env(name) - Unset an environment variable
+// Returns success(null) or failure(error)
+func! unset_env(name) = __env_unset(name);
+
+// env_all() - Returns all environment variables as a hash
+func env_all() = __env_list();
+
+// args() - Returns the command-line arguments as an array of strings
+// The first element is the program name (os.Args[0])
+func args() = __os_args();
+
+// exit(code) - Terminate the process with the given exit code
+// code must be an integer (e.g. 0 for success, 1 for error)
+func! exit(code) = __os_exit(code);

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1588,3 +1588,41 @@ func TestCachedModuleStruct(t *testing.T) {
 		t.Errorf("CachedModule.Name = %q, want %q", mod.Name, "testmodule")
 	}
 }
+
+// Test core.os module - env functions
+func TestCoreOSEnv(t *testing.T) {
+	// Set a test env var beforehand so we can read it back
+	t.Setenv("CALCIUM_TEST_VAR", "hello_calcium")
+
+	tests := []vmTestCase{
+		// env() returns success(value) when the variable exists; use !? to unwrap
+		{`use core.os; os.env("CALCIUM_TEST_VAR") !? { success(v) => v failure(e) => "" };`, "hello_calcium"},
+		// env() returns failure when the variable is not set
+		{`use core.os; os.env("CALCIUM_NONEXISTENT_XYZ_12345") !? { success(v) => true failure(e) => false };`, false},
+		// env_all() returns a hash containing the test variable
+		{`use core.os; has(os.env_all(), "CALCIUM_TEST_VAR");`, true},
+	}
+	runVmTests(t, tests)
+}
+
+// Test core.os module - args()
+func TestCoreOSArgs(t *testing.T) {
+	// os.Args always has at least the program name
+	input := `
+		use core.os;
+		len(os.args()) >= 1;
+	`
+	program := parse(input)
+	comp := compiler.New()
+	if err := comp.Compile(program); err != nil {
+		t.Fatalf("compiler error: %s", err)
+	}
+	vm := New(comp.Constants())
+	if err := vm.Run(comp.Bytecode().Instructions); err != nil {
+		t.Fatalf("vm error: %s", err)
+	}
+	result := vm.LastPoppedStackElem()
+	if !result.AsBool() {
+		t.Errorf("expected args() to return array with at least 1 element")
+	}
+}


### PR DESCRIPTION
Issue: gh-59

## 概要

CLIツール開発に必要な環境変数アクセス・プロセス制御機能を  モジュールとして追加します。

## 変更内容

### 追加した関数

| 関数 | 説明 |
|------|------|
|  | 環境変数を取得（ または  を返す） |
|  | 環境変数を設定（effect関数） |
|  | 環境変数を削除（effect関数） |
|  | 全環境変数をハッシュとして返す |
|  | コマンドライン引数を文字列の配列として返す |
|  | 指定コードでプロセスを終了（effect関数） |

### 使用例

```calcium
use core.os;

// 環境変数の取得
os.env("PATH") !? { success(v) => v failure(e) => "not set" };

// コマンドライン引数
args = os.args();
len(args);

// 環境変数の設定
os.set_env!("MY_VAR", "hello");
```

## 変更ファイル

-  - ,  プリミティブを追加
-  -  モジュール（新規作成）
-  - ,  テストを追加

## テスト結果

全テスト通過 (?   	github.com/ytnobody/calcium-lang/cmd/bone	[no test files]
?   	github.com/ytnobody/calcium-lang/cmd/calcium	[no test files]
ok  	github.com/ytnobody/calcium-lang/pkg/ast	(cached)
ok  	github.com/ytnobody/calcium-lang/pkg/bone	(cached)
ok  	github.com/ytnobody/calcium-lang/pkg/builtin	(cached)
ok  	github.com/ytnobody/calcium-lang/pkg/bytecode	(cached)
?   	github.com/ytnobody/calcium-lang/pkg/compiler	[no test files]
ok  	github.com/ytnobody/calcium-lang/pkg/lexer	(cached)
ok  	github.com/ytnobody/calcium-lang/pkg/optimizer	(cached)
ok  	github.com/ytnobody/calcium-lang/pkg/parser	(cached)
?   	github.com/ytnobody/calcium-lang/pkg/token	[no test files]
ok  	github.com/ytnobody/calcium-lang/pkg/value	(cached)
ok  	github.com/ytnobody/calcium-lang/pkg/vm	(cached))