### PR TITLE
gh-56: ファイルシステム操作の拡充（io モジュール）

### DIFF
--- a/pkg/vm/primitives.go
+++ b/pkg/vm/primitives.go
@@ -77,6 +77,93 @@ func primitiveWriteFile(args ...value.Value) value.Value {
 	return value.Success(value.Null())
 }
 
+// __list_dir lists entries in a directory
+func primitiveListDir(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__list_dir: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("__list_dir: path must be string"))
+	}
+	entries, err := os.ReadDir(args[0].AsString())
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("__list_dir: %v", err)))
+	}
+	result := make([]value.Value, len(entries))
+	for i, entry := range entries {
+		result[i] = value.String(entry.Name())
+	}
+	return value.Success(value.Array(result))
+}
+
+// __mkdir creates a directory (and parents)
+func primitiveMkdir(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__mkdir: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("__mkdir: path must be string"))
+	}
+	err := os.MkdirAll(args[0].AsString(), 0755)
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("__mkdir: %v", err)))
+	}
+	return value.Success(value.Null())
+}
+
+// __exists checks whether a file or directory exists
+func primitiveExists(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__exists: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("__exists: path must be string"))
+	}
+	_, err := os.Stat(args[0].AsString())
+	if err == nil {
+		return value.Bool(true)
+	}
+	if os.IsNotExist(err) {
+		return value.Bool(false)
+	}
+	return value.Failure(value.String(fmt.Sprintf("__exists: %v", err)))
+}
+
+// __delete_file deletes a file
+func primitiveDeleteFile(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__delete_file: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("__delete_file: path must be string"))
+	}
+	err := os.Remove(args[0].AsString())
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("__delete_file: %v", err)))
+	}
+	return value.Success(value.Null())
+}
+
+// __file_info returns metadata about a file or directory as a hash
+func primitiveFileInfo(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("__file_info: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("__file_info: path must be string"))
+	}
+	info, err := os.Stat(args[0].AsString())
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("__file_info: %v", err)))
+	}
+	h := value.NewHash()
+	h.Set(value.String("name"), value.String(info.Name()))
+	h.Set(value.String("size"), value.Int(info.Size()))
+	h.Set(value.String("is_dir"), value.Bool(info.IsDir()))
+	h.Set(value.String("modified"), value.String(info.ModTime().UTC().Format("2006-01-02T15:04:05Z")))
+	return value.Success(value.HashVal(h))
+}
+
 // =============================================================================
 // Math Primitives
 // =============================================================================
@@ -1367,10 +1454,15 @@ func primitiveOsExit(args ...value.Value) value.Value {
 func GetPrimitives() map[string]*value.Builtin {
 	return map[string]*value.Builtin{
 		// I/O
-		"__print":      {Name: "__print", Fn: primitiveprint},
-		"__println":    {Name: "__println", Fn: primitivePrintln},
-		"__read_file":  {Name: "__read_file", Fn: primitiveReadFile},
-		"__write_file": {Name: "__write_file", Fn: primitiveWriteFile},
+		"__print":       {Name: "__print", Fn: primitiveprint},
+		"__println":     {Name: "__println", Fn: primitivePrintln},
+		"__read_file":   {Name: "__read_file", Fn: primitiveReadFile},
+		"__write_file":  {Name: "__write_file", Fn: primitiveWriteFile},
+		"__list_dir":    {Name: "__list_dir", Fn: primitiveListDir},
+		"__mkdir":       {Name: "__mkdir", Fn: primitiveMkdir},
+		"__exists":      {Name: "__exists", Fn: primitiveExists},
+		"__delete_file": {Name: "__delete_file", Fn: primitiveDeleteFile},
+		"__file_info":   {Name: "__file_info", Fn: primitiveFileInfo},
 
 		// Math
 		"__floor": {Name: "__floor", Fn: primitiveFloor},

--- a/pkg/vm/stdlib/core/io.ca
+++ b/pkg/vm/stdlib/core/io.ca
@@ -1,5 +1,6 @@
 // core.io - Input/Output functions
-// Uses primitives: __print, __println, __read_file, __write_file
+// Uses primitives: __print, __println, __read_file, __write_file,
+//                  __list_dir, __mkdir, __exists, __delete_file, __file_info
 // Note: stdin and eof event sources are provided by the VM
 
 // print outputs a value without newline
@@ -47,3 +48,24 @@ func read_lines(path) =
 // write_lines writes an array of lines to a file
 func! write_lines(path, lines) =
     write_file(path, __str_join(lines, "\n"));
+
+// list_dir returns an array of file/directory names in the given directory
+// Returns success(array) or failure(error)
+func list_dir(path) = __list_dir(path);
+
+// mkdir creates a directory (and any necessary parents)
+// Returns success(null) or failure(error)
+func! mkdir(path) = __mkdir(path);
+
+// exists checks whether a file or directory exists at the given path
+// Returns true or false (or failure on permission errors)
+func exists(path) = __exists(path);
+
+// delete_file removes a file at the given path
+// Returns success(null) or failure(error)
+func! delete_file(path) = __delete_file(path);
+
+// file_info returns metadata about a file or directory as a hash
+// Hash keys: name, size, is_dir, modified
+// Returns success(hash) or failure(error)
+func file_info(path) = __file_info(path);

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -245,6 +245,11 @@ func (vm *VM) initModulesNoStdin() {
 	ioModule.Exports["read_file"] = value.BuiltinFunc(&value.Builtin{Name: "read_file", Fn: builtinReadFile})
 	ioModule.Exports["write_file"] = value.BuiltinFunc(&value.Builtin{Name: "write_file", Fn: builtinWriteFile})
 	ioModule.Exports["format"] = value.BuiltinFunc(&value.Builtin{Name: "format", Fn: builtinFormat})
+	ioModule.Exports["list_dir"] = value.BuiltinFunc(&value.Builtin{Name: "list_dir", Fn: builtinListDir})
+	ioModule.Exports["mkdir"] = value.BuiltinFunc(&value.Builtin{Name: "mkdir", Fn: builtinMkdir})
+	ioModule.Exports["exists"] = value.BuiltinFunc(&value.Builtin{Name: "exists", Fn: builtinExists})
+	ioModule.Exports["delete_file"] = value.BuiltinFunc(&value.Builtin{Name: "delete_file", Fn: builtinDeleteFile})
+	ioModule.Exports["file_info"] = value.BuiltinFunc(&value.Builtin{Name: "file_info", Fn: builtinFileInfo})
 	// stdin/eof not available in REPL mode
 	vm.modules["core.io"] = ioModule
 }
@@ -284,6 +289,11 @@ func (vm *VM) initModules() {
 	ioModule.Exports["read_file"] = value.BuiltinFunc(&value.Builtin{Name: "read_file", Fn: builtinReadFile})
 	ioModule.Exports["write_file"] = value.BuiltinFunc(&value.Builtin{Name: "write_file", Fn: builtinWriteFile})
 	ioModule.Exports["format"] = value.BuiltinFunc(&value.Builtin{Name: "format", Fn: builtinFormat})
+	ioModule.Exports["list_dir"] = value.BuiltinFunc(&value.Builtin{Name: "list_dir", Fn: builtinListDir})
+	ioModule.Exports["mkdir"] = value.BuiltinFunc(&value.Builtin{Name: "mkdir", Fn: builtinMkdir})
+	ioModule.Exports["exists"] = value.BuiltinFunc(&value.Builtin{Name: "exists", Fn: builtinExists})
+	ioModule.Exports["delete_file"] = value.BuiltinFunc(&value.Builtin{Name: "delete_file", Fn: builtinDeleteFile})
+	ioModule.Exports["file_info"] = value.BuiltinFunc(&value.Builtin{Name: "file_info", Fn: builtinFileInfo})
 	// Initialize stdin/eof event sources
 	vm.initStdinSource()
 	ioModule.Exports["stdin"] = value.EventSourceVal(vm.stdinSource)
@@ -2502,6 +2512,93 @@ func builtinWriteFile(args ...value.Value) value.Value {
 		return value.Failure(value.String(fmt.Sprintf("write_file: %v", err)))
 	}
 	return value.Success(value.Null())
+}
+
+// list_dir - lists files/directories in a directory (core.io)
+func builtinListDir(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("list_dir: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("list_dir: path must be string"))
+	}
+	entries, err := os.ReadDir(args[0].AsString())
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("list_dir: %v", err)))
+	}
+	result := make([]value.Value, len(entries))
+	for i, entry := range entries {
+		result[i] = value.String(entry.Name())
+	}
+	return value.Success(value.Array(result))
+}
+
+// mkdir - creates a directory (and parents) (core.io!)
+func builtinMkdir(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("mkdir: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("mkdir: path must be string"))
+	}
+	err := os.MkdirAll(args[0].AsString(), 0755)
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("mkdir: %v", err)))
+	}
+	return value.Success(value.Null())
+}
+
+// exists - checks if a file or directory exists (core.io)
+func builtinExists(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("exists: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("exists: path must be string"))
+	}
+	_, err := os.Stat(args[0].AsString())
+	if err == nil {
+		return value.Bool(true)
+	}
+	if os.IsNotExist(err) {
+		return value.Bool(false)
+	}
+	return value.Failure(value.String(fmt.Sprintf("exists: %v", err)))
+}
+
+// delete_file - deletes a file (core.io!)
+func builtinDeleteFile(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("delete_file: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("delete_file: path must be string"))
+	}
+	err := os.Remove(args[0].AsString())
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("delete_file: %v", err)))
+	}
+	return value.Success(value.Null())
+}
+
+// file_info - returns file metadata as a hash (core.io)
+func builtinFileInfo(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Failure(value.String("file_info: expected 1 argument (path)"))
+	}
+	if args[0].Type != value.TYPE_STRING {
+		return value.Failure(value.String("file_info: path must be string"))
+	}
+	info, err := os.Stat(args[0].AsString())
+	if err != nil {
+		return value.Failure(value.String(fmt.Sprintf("file_info: %v", err)))
+	}
+	h := value.NewHash()
+	h.Set(value.String("name"), value.String(info.Name()))
+	h.Set(value.String("size"), value.Int(info.Size()))
+	h.Set(value.String("is_dir"), value.Bool(info.IsDir()))
+	h.Set(value.String("modified"), value.String(info.ModTime().UTC().Format("2006-01-02T15:04:05Z")))
+	return value.Success(value.HashVal(h))
 }
 
 // format - formats a string with arguments (core.io)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ytnobody/calcium-lang/pkg/ast"
@@ -1646,4 +1648,99 @@ func TestDoExpression(t *testing.T) {
 		{`do y = 7; y * y end;`, 49},
 	}
 	runVmTests(t, tests)
+}
+
+// TestCoreIOFSFunctions tests the filesystem functions added to core.io
+func TestCoreIOFSFunctions(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+
+	// Write a test file
+	if err := os.WriteFile(testFile, []byte("hello"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// exists: file exists
+	existsResult := runVmExpr(t, `use core.io; io.exists("`+testFile+`");`)
+	if existsResult.Type != value.TYPE_BOOL || !existsResult.AsBool() {
+		t.Errorf("exists: expected true for existing file, got %v", existsResult)
+	}
+
+	// exists: missing file returns false
+	missingPath := filepath.Join(tmpDir, "no_such_file.txt")
+	notExistsResult := runVmExpr(t, `use core.io; io.exists("`+missingPath+`");`)
+	if notExistsResult.Type != value.TYPE_BOOL || notExistsResult.AsBool() {
+		t.Errorf("exists: expected false for missing file, got %v", notExistsResult)
+	}
+
+	// list_dir: directory listing returns success with array
+	listing := runVmExpr(t, `use core.io; io.list_dir("`+tmpDir+`");`)
+	if !listing.IsSuccess() {
+		t.Errorf("list_dir: expected success, got %v", listing)
+	}
+
+	// mkdir: create subdirectory
+	subDir := filepath.Join(tmpDir, "newdir")
+	mkdirResult := runVmExpr(t, `use core.io; io.mkdir("`+subDir+`");`)
+	if !mkdirResult.IsSuccess() {
+		t.Errorf("mkdir: expected success, got %v", mkdirResult)
+	}
+	if _, err := os.Stat(subDir); os.IsNotExist(err) {
+		t.Errorf("mkdir: directory was not created at %s", subDir)
+	}
+
+	// file_info: returns metadata hash with correct fields
+	infoResult := runVmExpr(t, `use core.io; io.file_info("`+testFile+`");`)
+	if !infoResult.IsSuccess() {
+		t.Errorf("file_info: expected success, got %v", infoResult)
+	} else {
+		h := infoResult.AsSuccess().AsHash()
+		name, ok := h.Get(value.String("name"))
+		if !ok || name.AsString() != "test.txt" {
+			t.Errorf("file_info: expected name=test.txt, got %v", name)
+		}
+		isDir, ok := h.Get(value.String("is_dir"))
+		if !ok || isDir.AsBool() {
+			t.Errorf("file_info: expected is_dir=false")
+		}
+		_, ok = h.Get(value.String("size"))
+		if !ok {
+			t.Errorf("file_info: expected size key in result")
+		}
+		_, ok = h.Get(value.String("modified"))
+		if !ok {
+			t.Errorf("file_info: expected modified key in result")
+		}
+	}
+
+	// delete_file: remove existing file
+	deleteResult := runVmExpr(t, `use core.io; io.delete_file("`+testFile+`");`)
+	if !deleteResult.IsSuccess() {
+		t.Errorf("delete_file: expected success, got %v", deleteResult)
+	}
+	if _, err := os.Stat(testFile); !os.IsNotExist(err) {
+		t.Errorf("delete_file: file still exists after delete")
+	}
+
+	// delete_file: returns failure for nonexistent file
+	deleteFailResult := runVmExpr(t, `use core.io; io.delete_file("`+testFile+`");`)
+	if !deleteFailResult.IsFailure() {
+		t.Errorf("delete_file: expected failure for nonexistent file, got %v", deleteFailResult)
+	}
+}
+
+// runVmExpr runs a Calcium expression and returns the last stack element
+func runVmExpr(t *testing.T, input string) value.Value {
+	t.Helper()
+	program := parse(input)
+	comp := compiler.New()
+	if err := comp.Compile(program); err != nil {
+		t.Fatalf("compiler error: %s", err)
+	}
+	machine := New(comp.Constants())
+	if err := machine.Run(comp.Bytecode().Instructions); err != nil {
+		t.Fatalf("vm error: %s", err)
+	}
+	return machine.LastPoppedStackElem()
 }


### PR DESCRIPTION
Issue: gh-56

## 変更内容

`core.io` モジュールに以下のファイルシステム操作関数を追加:

- `io.list_dir(path)` - ディレクトリ内のファイル/ディレクトリ名一覧を返す（`success(array)` または `failure(error)`）
- `io.mkdir(path)` - ディレクトリを作成する（中間ディレクトリも含む）
- `io.exists(path)` - ファイル/ディレクトリの存在確認（`true`/`false` を返す）
- `io.delete_file(path)` - ファイルを削除する
- `io.file_info(path)` - ファイルメタ情報をハッシュで返す（`name`, `size`, `is_dir`, `modified`）

## 実装詳細

- `pkg/vm/vm.go`: Go builtins として `initModules` / `initModulesNoStdin` 両方に登録
- `pkg/vm/primitives.go`: `__list_dir` 等の `__` プレフィックスプリミティブとして `GetPrimitives()` に登録
- `pkg/vm/stdlib/core/io.ca`: Calcium 側ラッパー関数を追加

## テスト

`TestCoreIOFSFunctions` を追加し、全関数の動作を一時ディレクトリで検証。
全テスト通過済み。