### PR TITLE
gh-53: implement guard clause pattern matching

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -359,8 +359,10 @@ func (me *MatchExpression) TokenLiteral() string { return me.Token.Literal }
 type MatchCase struct {
 	Token     token.Token // the '=>' token
 	Pattern   Expression  // pattern or condition
+	Guard     Expression  // optional guard condition (nil if no guard); e.g. "if x > 0"
 	Body      Expression
 	IsDefault bool // true if pattern is _
+	IsBinding bool // true if pattern is a variable binding (identifier captures subject value)
 }
 
 // EffectHandleExpression represents !? { success(r) => ... failure(e) => ... }

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1346,30 +1346,80 @@ func (c *Compiler) compileMatch(node *ast.MatchExpression) error {
 	for i, mc := range node.Cases {
 		isLast := i == len(node.Cases)-1
 
-		// Duplicate subject for comparison
+		// Duplicate subject for comparison/binding (always needed so subject stays on stack for next cases)
 		c.emit(bytecode.OpDup)
 
-		if mc.IsDefault {
+		// jumpToNextPositions holds all OpJumpIfFalse instruction positions
+		// that should jump to the start of the next case.
+		jumpToNextPositions := []int{}
+
+		if mc.IsBinding {
+			// Binding pattern: bind the subject copy to a local variable, then check guard.
+			// e.g. "x if x > 0 => ..." binds subject to x, evaluates guard x > 0.
+			pattern, ok := mc.Pattern.(*ast.Identifier)
+			if !ok {
+				return fmt.Errorf("binding pattern must be an identifier, got %T", mc.Pattern)
+			}
+			symbol := c.symbolTable.Define(pattern.Value)
+			if symbol.Scope == GlobalScope {
+				c.emit(bytecode.OpSetGlobal, symbol.Index)
+			} else {
+				c.emit(bytecode.OpSetLocal, symbol.Index)
+			}
+			// Evaluate guard condition
+			if mc.Guard != nil {
+				err = c.Compile(mc.Guard)
+				if err != nil {
+					return err
+				}
+				if !isLast {
+					jumpToNextPositions = append(jumpToNextPositions, c.emit(bytecode.OpJumpIfFalse, 9999))
+				} else {
+					// Last case: discard guard result so stack stays consistent
+					c.emit(bytecode.OpPop)
+				}
+			}
+		} else if mc.IsDefault {
 			// Default case: always matches, pop the duplicate
 			c.emit(bytecode.OpPop)
+			// Guard on default case (rare but supported)
+			if mc.Guard != nil {
+				err = c.Compile(mc.Guard)
+				if err != nil {
+					return err
+				}
+				if !isLast {
+					jumpToNextPositions = append(jumpToNextPositions, c.emit(bytecode.OpJumpIfFalse, 9999))
+				} else {
+					c.emit(bytecode.OpPop)
+				}
+			}
 		} else {
-			// Compile pattern/condition
+			// Regular pattern: compare subject copy with pattern value
 			err := c.Compile(mc.Pattern)
 			if err != nil {
 				return err
 			}
-
-			// Compare
 			c.emit(bytecode.OpEqual)
+			// Jump to next case if pattern doesn't match
+			if !isLast || mc.Guard != nil {
+				jumpToNextPositions = append(jumpToNextPositions, c.emit(bytecode.OpJumpIfFalse, 9999))
+			}
+			// Guard: additional condition after pattern match
+			if mc.Guard != nil {
+				err = c.Compile(mc.Guard)
+				if err != nil {
+					return err
+				}
+				if !isLast {
+					jumpToNextPositions = append(jumpToNextPositions, c.emit(bytecode.OpJumpIfFalse, 9999))
+				} else {
+					c.emit(bytecode.OpPop)
+				}
+			}
 		}
 
-		var jumpToNextPos int
-		if !isLast && !mc.IsDefault {
-			// Jump to next case if no match
-			jumpToNextPos = c.emit(bytecode.OpJumpIfFalse, 9999)
-		}
-
-		// Pop subject (matched)
+		// Pop subject from stack (either original subject or the remaining copy after binding)
 		c.emit(bytecode.OpPop)
 
 		// Compile body
@@ -1383,10 +1433,10 @@ func (c *Compiler) compileMatch(node *ast.MatchExpression) error {
 			jumpToEndPositions = append(jumpToEndPositions, c.emit(bytecode.OpJump, 9999))
 		}
 
-		if !isLast && !mc.IsDefault {
-			// Patch jump to next case
-			afterPos := len(c.currentInstructions())
-			c.changeOperand(jumpToNextPos, afterPos)
+		// Patch all jumps to next case (they now point right after the body/jump-to-end)
+		afterPos := len(c.currentInstructions())
+		for _, pos := range jumpToNextPositions {
+			c.changeOperand(pos, afterPos)
 		}
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1386,9 +1386,23 @@ func (p *Parser) parseMatchCase() *ast.MatchCase {
 	if p.curTokenIs(token.UNDERSCORE) {
 		mc.IsDefault = true
 		mc.Pattern = &ast.WildcardExpression{Token: p.curToken}
+	} else if p.curTokenIs(token.IDENT) && p.peekTokenIs(token.IF) {
+		// Binding pattern: identifier followed by 'if' guard
+		// e.g. "x if x > 0 => ..."
+		mc.IsBinding = true
+		mc.Pattern = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+		p.nextToken() // consume 'if'
+		p.nextToken() // move to guard expression
+		mc.Guard = p.parseExpression(LAMBDA)
 	} else {
 		// Parse pattern/condition - use LAMBDA precedence to stop before =>
 		mc.Pattern = p.parseExpression(LAMBDA)
+		// Check for guard after pattern: "pattern if condition => ..."
+		if p.peekTokenIs(token.IF) {
+			p.nextToken() // consume 'if'
+			p.nextToken() // move to guard expression
+			mc.Guard = p.parseExpression(LAMBDA)
+		}
 	}
 
 	// Expect =>

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -695,6 +695,88 @@ func TestMatchExpression(t *testing.T) {
 	}
 }
 
+func TestMatchGuardExpression(t *testing.T) {
+	input := `match n
+		x if x > 0 => "positive"
+		0           => "zero"
+		_           => "negative";`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	match, ok := stmt.Expression.(*ast.MatchExpression)
+	if !ok {
+		t.Fatalf("exp not ast.MatchExpression. got=%T", stmt.Expression)
+	}
+
+	if len(match.Cases) != 3 {
+		t.Fatalf("match.Cases wrong. expected=3, got=%d", len(match.Cases))
+	}
+
+	// First case: binding pattern with guard
+	firstCase := match.Cases[0]
+	if !firstCase.IsBinding {
+		t.Errorf("first case should be a binding pattern")
+	}
+	if firstCase.Guard == nil {
+		t.Errorf("first case should have a guard")
+	}
+	ident, ok := firstCase.Pattern.(*ast.Identifier)
+	if !ok {
+		t.Errorf("first case pattern should be an Identifier, got=%T", firstCase.Pattern)
+	} else if ident.Value != "x" {
+		t.Errorf("first case binding name should be 'x', got=%s", ident.Value)
+	}
+
+	// Second case: regular pattern, no guard
+	if match.Cases[1].Guard != nil {
+		t.Errorf("second case should not have a guard")
+	}
+	if match.Cases[1].IsBinding {
+		t.Errorf("second case should not be a binding")
+	}
+
+	// Third case: default
+	if !match.Cases[2].IsDefault {
+		t.Errorf("third case should be default")
+	}
+}
+
+func TestMatchPatternGuardExpression(t *testing.T) {
+	// Test guard on regular pattern (not binding)
+	input := `match n
+		1 if n > 10 => "big one"
+		1           => "small one"
+		_           => "other";`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	match, ok := stmt.Expression.(*ast.MatchExpression)
+	if !ok {
+		t.Fatalf("exp not ast.MatchExpression. got=%T", stmt.Expression)
+	}
+
+	if len(match.Cases) != 3 {
+		t.Fatalf("match.Cases wrong. expected=3, got=%d", len(match.Cases))
+	}
+
+	// First case: pattern with guard
+	firstCase := match.Cases[0]
+	if firstCase.IsBinding {
+		t.Errorf("first case should not be a binding pattern")
+	}
+	if firstCase.Guard == nil {
+		t.Errorf("first case should have a guard")
+	}
+}
+
 func TestCallExpression(t *testing.T) {
 	input := `add(1, 2 * 3, 4 + 5);`
 

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -90,6 +90,7 @@ const (
 	IN          TokenType = "IN"
 	DO          TokenType = "DO"
 	END         TokenType = "END"
+	IF          TokenType = "IF"
 
 	// Built-in function keywords
 	MAP    TokenType = "MAP"
@@ -119,6 +120,7 @@ var keywords = map[string]TokenType{
 	"return":     RETURN,
 	"in":         IN,
 	"do":         DO,
+	"if":         IF,
 	"map":        MAP,
 	"filter":     FILTER,
 	"reduce":     REDUCE,

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -400,6 +400,44 @@ func TestMatchExpression(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestMatchGuardExpression(t *testing.T) {
+	tests := []vmTestCase{
+		// Binding pattern with guard: "x if x > 0 => ..."
+		{
+			input:    `n = 5; match n x if x > 0 => "positive" _ => "other";`,
+			expected: "positive",
+		},
+		{
+			input:    `n = -3; match n x if x > 0 => "positive" _ => "other";`,
+			expected: "other",
+		},
+		{
+			input:    `n = 0; match n x if x > 0 => "positive" 0 => "zero" _ => "negative";`,
+			expected: "zero",
+		},
+		// Pattern with guard: "1 if condition => ..."
+		{
+			input:    `n = 1; match n 1 if n > 0 => "positive one" 1 => "one" _ => "other";`,
+			expected: "positive one",
+		},
+		{
+			input:    `n = 1; match n 1 if n > 10 => "big one" 1 => "small one" _ => "other";`,
+			expected: "small one",
+		},
+		// Multiple binding cases with guards
+		{
+			input:    `n = 10; match n x if x > 5 => "big" x if x > 0 => "small" _ => "non-positive";`,
+			expected: "big",
+		},
+		{
+			input:    `n = 3; match n x if x > 5 => "big" x if x > 0 => "small" _ => "non-positive";`,
+			expected: "small",
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
 func TestPipeOperator(t *testing.T) {
 	tests := []vmTestCase{
 		{


### PR DESCRIPTION
## Summary

- Add `if` keyword token to the lexer
- Extend `MatchCase` AST node with `Guard` (optional condition) and `IsBinding` (variable capture) fields
- Parser: recognize `x if x > 0 => body` (binding with guard) and `pat if cond => body` (value pattern with guard)
- Compiler: emit guard condition evaluation and conditional jump to next case when guard fails; binding patterns assign subject to a local variable before guard evaluation

## Example

```
match n
    x if x > 0 => "positive"
    0           => "zero"
    _           => "negative"
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Parser tests: `TestMatchGuardExpression`, `TestMatchPatternGuardExpression`
- [x] VM integration tests: `TestMatchGuardExpression` (7 cases including binding patterns, pattern guards, multiple guards)

Issue: gh-53