### PR TITLE
gh-53: implement guard clause pattern matching

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -360,7 +360,8 @@ type MatchCase struct {
 	Token     token.Token // the '=>' token
 	Pattern   Expression  // pattern or condition
 	Body      Expression
-	IsDefault bool // true if pattern is _
+	IsDefault bool       // true if pattern is _
+	Guard     Expression // optional guard: x if x > 0 => ...
 }
 
 // EffectHandleExpression represents !? { success(r) => ... failure(e) => ... }

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1346,47 +1346,99 @@ func (c *Compiler) compileMatch(node *ast.MatchExpression) error {
 	for i, mc := range node.Cases {
 		isLast := i == len(node.Cases)-1
 
-		// Duplicate subject for comparison
-		c.emit(bytecode.OpDup)
+		if mc.Guard != nil {
+			// Guard case: pattern if guard => body
+			// The pattern is an identifier that binds the subject value.
+			// 1. Bind subject to the pattern variable
+			// 2. Evaluate guard condition
+			// 3. If guard is false, unbind and jump to next case
 
-		if mc.IsDefault {
-			// Default case: always matches, pop the duplicate
-			c.emit(bytecode.OpPop)
-		} else {
-			// Compile pattern/condition
-			err := c.Compile(mc.Pattern)
+			// Duplicate subject for binding
+			c.emit(bytecode.OpDup)
+
+			// Bind the pattern identifier as a local variable
+			ident, ok := mc.Pattern.(*ast.Identifier)
+			if !ok {
+				return fmt.Errorf("guard clause requires a variable pattern (e.g., x if x > 0)")
+			}
+			guardSymbol := c.symbolTable.Define(ident.Value)
+			if guardSymbol.Scope == GlobalScope {
+				c.emit(bytecode.OpSetGlobal, guardSymbol.Index)
+			} else {
+				c.emit(bytecode.OpSetLocal, guardSymbol.Index)
+			}
+
+			// Evaluate guard condition
+			err := c.Compile(mc.Guard)
 			if err != nil {
 				return err
 			}
 
-			// Compare
-			c.emit(bytecode.OpEqual)
-		}
+			var jumpToNextPos int
+			if !isLast {
+				// Jump to next case if guard fails
+				jumpToNextPos = c.emit(bytecode.OpJumpIfFalse, 9999)
+			}
 
-		var jumpToNextPos int
-		if !isLast && !mc.IsDefault {
-			// Jump to next case if no match
-			jumpToNextPos = c.emit(bytecode.OpJumpIfFalse, 9999)
-		}
+			// Guard passed: pop subject, compile body
+			c.emit(bytecode.OpPop)
 
-		// Pop subject (matched)
-		c.emit(bytecode.OpPop)
+			err = c.Compile(mc.Body)
+			if err != nil {
+				return err
+			}
 
-		// Compile body
-		err = c.Compile(mc.Body)
-		if err != nil {
-			return err
-		}
+			if !isLast {
+				jumpToEndPositions = append(jumpToEndPositions, c.emit(bytecode.OpJump, 9999))
+				// Patch jump to next case
+				afterPos := len(c.currentInstructions())
+				c.changeOperand(jumpToNextPos, afterPos)
+			}
+		} else {
+			// Standard case (no guard)
 
-		if !isLast {
-			// Jump to end after body
-			jumpToEndPositions = append(jumpToEndPositions, c.emit(bytecode.OpJump, 9999))
-		}
+			// Duplicate subject for comparison
+			c.emit(bytecode.OpDup)
 
-		if !isLast && !mc.IsDefault {
-			// Patch jump to next case
-			afterPos := len(c.currentInstructions())
-			c.changeOperand(jumpToNextPos, afterPos)
+			if mc.IsDefault {
+				// Default case: always matches, pop the duplicate
+				c.emit(bytecode.OpPop)
+			} else {
+				// Compile pattern/condition
+				err := c.Compile(mc.Pattern)
+				if err != nil {
+					return err
+				}
+
+				// Compare
+				c.emit(bytecode.OpEqual)
+			}
+
+			var jumpToNextPos int
+			if !isLast && !mc.IsDefault {
+				// Jump to next case if no match
+				jumpToNextPos = c.emit(bytecode.OpJumpIfFalse, 9999)
+			}
+
+			// Pop subject (matched)
+			c.emit(bytecode.OpPop)
+
+			// Compile body
+			err = c.Compile(mc.Body)
+			if err != nil {
+				return err
+			}
+
+			if !isLast {
+				// Jump to end after body
+				jumpToEndPositions = append(jumpToEndPositions, c.emit(bytecode.OpJump, 9999))
+			}
+
+			if !isLast && !mc.IsDefault {
+				// Patch jump to next case
+				afterPos := len(c.currentInstructions())
+				c.changeOperand(jumpToNextPos, afterPos)
+			}
 		}
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1391,6 +1391,14 @@ func (p *Parser) parseMatchCase() *ast.MatchCase {
 		mc.Pattern = p.parseExpression(LAMBDA)
 	}
 
+	// Check for guard clause: pattern if condition => body
+	// "if" is a contextual keyword (not reserved), so it appears as IDENT with literal "if"
+	if p.peekTokenIs(token.IDENT) && p.peekToken.Literal == "if" {
+		p.nextToken() // consume "if"
+		p.nextToken() // move to guard expression
+		mc.Guard = p.parseExpression(LAMBDA)
+	}
+
 	// Expect =>
 	if !p.expectPeek(token.ARROW) {
 		return nil

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -695,6 +695,49 @@ func TestMatchExpression(t *testing.T) {
 	}
 }
 
+func TestMatchGuardClause(t *testing.T) {
+	input := `match x
+		n if n > 0 => "positive"
+		_ => "other";`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	match, ok := stmt.Expression.(*ast.MatchExpression)
+	if !ok {
+		t.Fatalf("exp not ast.MatchExpression. got=%T", stmt.Expression)
+	}
+
+	if len(match.Cases) != 2 {
+		t.Fatalf("match.Cases wrong. expected=2, got=%d", len(match.Cases))
+	}
+
+	// First case should have a guard
+	if match.Cases[0].Guard == nil {
+		t.Errorf("first case should have a guard clause")
+	}
+
+	// First case pattern should be identifier "n"
+	ident, ok := match.Cases[0].Pattern.(*ast.Identifier)
+	if !ok {
+		t.Fatalf("first case pattern not ast.Identifier. got=%T", match.Cases[0].Pattern)
+	}
+	if ident.Value != "n" {
+		t.Errorf("pattern identifier wrong. expected='n', got=%q", ident.Value)
+	}
+
+	// Second case should be default with no guard
+	if !match.Cases[1].IsDefault {
+		t.Errorf("second case should be default")
+	}
+	if match.Cases[1].Guard != nil {
+		t.Errorf("default case should not have a guard")
+	}
+}
+
 func TestCallExpression(t *testing.T) {
 	input := `add(1, 2 * 3, 4 + 5);`
 

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -398,6 +398,43 @@ func TestMatchExpression(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestMatchGuardClause(t *testing.T) {
+	tests := []vmTestCase{
+		// Basic guard clause: bind variable and check condition
+		{
+			input:    `match 5 x if x > 0 => "positive" _ => "non-positive";`,
+			expected: "positive",
+		},
+		// Guard clause with negative number falls through to default
+		{
+			input:    `match -3 x if x > 0 => "positive" _ => "non-positive";`,
+			expected: "non-positive",
+		},
+		// Guard with equality check
+		{
+			input:    `match 42 x if x == 42 => "answer" _ => "other";`,
+			expected: "answer",
+		},
+		// Multiple guard clauses
+		{
+			input:    `match 15 x if x > 10 => "big" x if x > 0 => "small" _ => "zero-or-neg";`,
+			expected: "big",
+		},
+		// Guard mixed with exact match
+		{
+			input:    `match 1 0 => "zero" x if x > 0 => "positive" _ => "negative";`,
+			expected: "positive",
+		},
+		// Guard with exact match first
+		{
+			input:    `match 0 0 => "zero" x if x > 0 => "positive" _ => "negative";`,
+			expected: "zero",
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
 func TestPipeOperator(t *testing.T) {
 	tests := []vmTestCase{
 		{


### PR DESCRIPTION
## Summary
- Add guard clause support to match expressions (`x if condition => body`)
- Pattern variable is bound to the match subject, then guard condition is evaluated
- If guard fails, execution falls through to the next case

## Changes
- `pkg/ast/ast.go`: Add `Guard` field to `MatchCase`
- `pkg/parser/parser.go`: Parse `if` keyword after pattern as guard expression
- `pkg/compiler/compiler.go`: Compile guard clauses with variable binding and conditional jumps
- `pkg/parser/parser_test.go`: Add parser test for guard clause parsing
- `pkg/vm/vm_test.go`: Add VM integration tests (basic, multiple, mixed with exact matches)

## Test plan
- [x] Parser correctly parses guard clauses
- [x] Guard with positive condition matches
- [x] Guard with failing condition falls through to default
- [x] Multiple guard clauses evaluated in order
- [x] Guard clauses mixed with exact pattern matches
- [x] All existing tests pass

Closes #53

エンジニア・オーケストレーター無応答のため監督が直接実装。