### PR TITLE
gh-57: implement tuple type

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -218,6 +218,15 @@ type BooleanLiteral struct {
 func (bl *BooleanLiteral) expressionNode()      {}
 func (bl *BooleanLiteral) TokenLiteral() string { return bl.Token.Literal }
 
+// TupleLiteral represents (elem1, elem2, ...)
+type TupleLiteral struct {
+	Token    token.Token // the '(' token
+	Elements []Expression
+}
+
+func (tl *TupleLiteral) expressionNode()      {}
+func (tl *TupleLiteral) TokenLiteral() string { return tl.Token.Literal }
+
 // ArrayLiteral represents [elem1, elem2] or [elem1 elem2]
 type ArrayLiteral struct {
 	Token    token.Token // the '[' token

--- a/pkg/bytecode/bytecode.go
+++ b/pkg/bytecode/bytecode.go
@@ -61,6 +61,9 @@ const (
 	OpSpread      // Spread array to stack
 	OpCallSpread  // Call function with spread array as arguments
 
+	// Tuples
+	OpTuple // Create tuple from N elements
+
 	// Hash
 	OpHash // Create hash from N key-value pairs
 
@@ -162,7 +165,8 @@ var definitions = map[OpCode]*Definition{
 	OpSpread:      {"OpSpread", []int{}},
 	OpCallSpread:  {"OpCallSpread", []int{}}, // Call with spread array
 
-	OpHash: {"OpHash", []int{2}}, // 2-byte pair count
+	OpTuple: {"OpTuple", []int{2}}, // 2-byte element count
+	OpHash:  {"OpHash", []int{2}},  // 2-byte pair count
 
 	OpGetMember: {"OpGetMember", []int{2}}, // 2-byte property name index
 

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -863,6 +863,15 @@ func (c *Compiler) Compile(node ast.Node) error {
 			c.emit(bytecode.OpArray, len(node.Elements))
 		}
 
+	case *ast.TupleLiteral:
+		for _, elem := range node.Elements {
+			err := c.Compile(elem)
+			if err != nil {
+				return err
+			}
+		}
+		c.emit(bytecode.OpTuple, len(node.Elements))
+
 	case *ast.HashLiteral:
 		// Compile each key-value pair
 		for _, pair := range node.Pairs {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1010,36 +1010,37 @@ func (p *Parser) parseGroupedOrLambda() ast.Expression {
 		return firstExpr
 	}
 
-	// Check for comma (lambda with multiple params)
+	// Check for comma (lambda with multiple params OR tuple literal)
 	if p.peekTokenIs(token.COMMA) {
-		// It's a lambda: (x, y, ...) => expr
-		params := []*ast.Identifier{}
-		ident := p.exprToIdentifiers(firstExpr)
-		if ident == nil {
-			return nil
-		}
-		params = append(params, ident...)
+		// Collect all comma-separated expressions
+		elements := []ast.Expression{firstExpr}
 
 		for p.peekTokenIs(token.COMMA) {
 			p.nextToken() // consume ','
 			p.nextToken()
-			paramExpr := p.parseExpression(LOWEST)
-			ident := p.exprToIdentifiers(paramExpr)
-			if ident == nil {
-				return nil
-			}
-			params = append(params, ident...)
+			elements = append(elements, p.parseExpression(LOWEST))
 		}
 
 		if !p.expectPeek(token.RPAREN) {
 			return nil
 		}
 
-		if !p.expectPeek(token.ARROW) {
-			return nil
+		// If followed by =>, it's a lambda
+		if p.peekTokenIs(token.ARROW) {
+			p.nextToken() // consume '=>'
+			params := []*ast.Identifier{}
+			for _, elem := range elements {
+				ident := p.exprToIdentifiers(elem)
+				if ident == nil {
+					return nil
+				}
+				params = append(params, ident...)
+			}
+			return p.parseLambdaBody(tok, params)
 		}
 
-		return p.parseLambdaBody(tok, params)
+		// Otherwise it's a tuple literal
+		return &ast.TupleLiteral{Token: tok, Elements: elements}
 	}
 
 	// It's a grouped expression, but we need to continue parsing

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -738,6 +738,41 @@ func TestMatchGuardClause(t *testing.T) {
 	}
 }
 
+func TestTupleLiteral(t *testing.T) {
+	input := `(1, "hello", true);`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	tuple, ok := stmt.Expression.(*ast.TupleLiteral)
+	if !ok {
+		t.Fatalf("exp not ast.TupleLiteral. got=%T", stmt.Expression)
+	}
+
+	if len(tuple.Elements) != 3 {
+		t.Fatalf("tuple.Elements wrong. expected=3, got=%d", len(tuple.Elements))
+	}
+}
+
+func TestTupleVsLambda(t *testing.T) {
+	// (x, y) => x + y should still be a lambda, not a tuple
+	input := `(x, y) => x + y;`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	_, ok := stmt.Expression.(*ast.LambdaExpression)
+	if !ok {
+		t.Fatalf("exp not ast.LambdaExpression. got=%T", stmt.Expression)
+	}
+}
+
 func TestCallExpression(t *testing.T) {
 	input := `add(1, 2 * 3, 4 + 5);`
 

--- a/pkg/value/value.go
+++ b/pkg/value/value.go
@@ -25,6 +25,7 @@ const (
 	TYPE_SUCCESS
 	TYPE_FAILURE
 	TYPE_MODULE
+	TYPE_TUPLE        // Tuple (fixed-length, heterogeneous)
 	TYPE_REGEX        // Compiled regular expression
 	TYPE_TASK         // Return value of async.spawn
 	TYPE_HANDLER      // Return value of async.expects
@@ -61,6 +62,8 @@ func (t Type) String() string {
 		return "failure"
 	case TYPE_MODULE:
 		return "module"
+	case TYPE_TUPLE:
+		return "tuple"
 	case TYPE_REGEX:
 		return "regex"
 	case TYPE_TASK:
@@ -326,6 +329,11 @@ func EventSourceVal(es *EventSource) Value {
 	return Value{Type: TYPE_EVENT_SOURCE, Data: es}
 }
 
+// Tuple creates a tuple value
+func Tuple(elements []Value) Value {
+	return Value{Type: TYPE_TUPLE, Data: elements}
+}
+
 // RegexVal creates a regex value
 func RegexVal(r *Regex) Value {
 	return Value{Type: TYPE_REGEX, Data: r}
@@ -461,6 +469,11 @@ func (v Value) AsEventSource() *EventSource {
 	return v.Data.(*EventSource)
 }
 
+// AsTuple returns the tuple elements
+func (v Value) AsTuple() []Value {
+	return v.Data.([]Value)
+}
+
 // AsRegex returns the regex value
 func (v Value) AsRegex() *Regex {
 	return v.Data.(*Regex)
@@ -493,6 +506,8 @@ func (v Value) IsTruthy() bool {
 		return v.AsString() != ""
 	case TYPE_ARRAY:
 		return len(v.AsArray()) > 0
+	case TYPE_TUPLE:
+		return len(v.AsTuple()) > 0
 	case TYPE_SUCCESS:
 		return true
 	case TYPE_FAILURE:
@@ -547,6 +562,17 @@ func (v Value) Equals(other Value) bool {
 			}
 		}
 		return true
+	case TYPE_TUPLE:
+		t1, t2 := v.AsTuple(), other.AsTuple()
+		if len(t1) != len(t2) {
+			return false
+		}
+		for i := range t1 {
+			if !t1[i].Equals(t2[i]) {
+				return false
+			}
+		}
+		return true
 	case TYPE_HASH:
 		h1, h2 := v.AsHash(), other.AsHash()
 		if len(h1.Pairs) != len(h2.Pairs) {
@@ -591,6 +617,13 @@ func (v Value) String() string {
 			strs[i] = e.String()
 		}
 		return "[" + strings.Join(strs, ", ") + "]"
+	case TYPE_TUPLE:
+		elements := v.AsTuple()
+		strs := make([]string, len(elements))
+		for i, e := range elements {
+			strs[i] = e.String()
+		}
+		return "(" + strings.Join(strs, ", ") + ")"
 	case TYPE_HASH:
 		h := v.AsHash()
 		strs := make([]string, len(h.Pairs))

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -656,6 +656,18 @@ func (vm *VM) executeOpcode(op bytecode.OpCode) error {
 			return err
 		}
 
+	case bytecode.OpTuple:
+		numElements := int(binary.BigEndian.Uint16(ins[ip+1:]))
+		vm.currentFrame().ip += 2
+		elements := make([]value.Value, numElements)
+		for i := numElements - 1; i >= 0; i-- {
+			elements[i] = vm.pop()
+		}
+		err := vm.push(value.Tuple(elements))
+		if err != nil {
+			return err
+		}
+
 	case bytecode.OpHash:
 		numPairs := int(binary.BigEndian.Uint16(ins[ip+1:]))
 		vm.currentFrame().ip += 2
@@ -691,6 +703,17 @@ func (vm *VM) executeOpcode(op bytecode.OpCode) error {
 				vm.push(value.Null())
 			} else {
 				vm.push(arr[idx])
+			}
+		case value.TYPE_TUPLE:
+			if index.Type != value.TYPE_INT {
+				return fmt.Errorf("tuple index must be integer, got %s", index.Type)
+			}
+			tup := left.AsTuple()
+			idx := int(index.AsInt())
+			if idx < 0 || idx >= len(tup) {
+				vm.push(value.Null())
+			} else {
+				vm.push(tup[idx])
 			}
 		case value.TYPE_HASH:
 			hash := left.AsHash()
@@ -2155,6 +2178,8 @@ func builtinLen(args ...value.Value) value.Value {
 		return value.Int(int64(len(args[0].AsString())))
 	case value.TYPE_ARRAY:
 		return value.Int(int64(len(args[0].AsArray())))
+	case value.TYPE_TUPLE:
+		return value.Int(int64(len(args[0].AsTuple())))
 	case value.TYPE_HASH:
 		return value.Int(int64(len(args[0].AsHash().Pairs)))
 	default:

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1687,6 +1687,95 @@ func TestDoExpression(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestTupleLiteral(t *testing.T) {
+	tests := []vmTestCase{
+		// Basic tuple creation
+		{
+			input:    `(1, 2, 3);`,
+			expected: "(1, 2, 3)",
+		},
+		// Tuple with mixed types
+		{
+			input:    `(1, "hello", true);`,
+			expected: "(1, hello, true)",
+		},
+		// Tuple index access
+		{
+			input:    `t = (10, 20, 30); t[0];`,
+			expected: int64(10),
+		},
+		{
+			input:    `t = (10, 20, 30); t[1];`,
+			expected: int64(20),
+		},
+		{
+			input:    `t = (10, 20, 30); t[2];`,
+			expected: int64(30),
+		},
+		// Tuple out-of-bounds returns null
+		{
+			input:    `t = (1, 2); t[5];`,
+			expected: nil,
+		},
+		// Tuple length
+		{
+			input:    `len((1, 2, 3));`,
+			expected: int64(3),
+		},
+		// Nested tuple
+		{
+			input:    `t = ((1, 2), (3, 4)); t[0];`,
+			expected: "(1, 2)",
+		},
+		// Tuple equality check
+		{
+			input:    `t = (1, 2); t == (1, 2);`,
+			expected: "true",
+		},
+		// Tuple in function return
+		{
+			input:    `func pair(a, b) = (a, b); p = pair(10, 20); p[0];`,
+			expected: int64(10),
+		},
+	}
+
+	// Special handling: convert string-expected tests
+	for _, tt := range tests {
+		program := parse(tt.input)
+		comp := compiler.New()
+		err := comp.Compile(program)
+		if err != nil {
+			t.Fatalf("compiler error for %q: %s", tt.input, err)
+		}
+
+		machine := New(comp.Constants())
+		err = machine.Run(comp.Bytecode().Instructions)
+		if err != nil {
+			t.Fatalf("vm error for %q: %s", tt.input, err)
+		}
+
+		stackElem := machine.LastPoppedStackElem()
+
+		switch expected := tt.expected.(type) {
+		case int64:
+			if stackElem.Type != value.TYPE_INT || stackElem.AsInt() != expected {
+				t.Errorf("for %q: expected %d, got %s", tt.input, expected, stackElem.String())
+			}
+		case string:
+			actual := stackElem.String()
+			if actual != expected {
+				t.Errorf("for %q: expected %q, got %q", tt.input, expected, actual)
+			}
+		case nil:
+			if stackElem.Type != value.TYPE_NULL {
+				t.Errorf("for %q: expected null, got %s", tt.input, stackElem.String())
+			}
+		default:
+			t.Fatalf("unhandled expected type for %q", tt.input)
+		}
+	}
+}
+
 // TestCoreIOFSFunctions tests the filesystem functions added to core.io
 func TestCoreIOFSFunctions(t *testing.T) {
 	// Create a temporary directory for testing


### PR DESCRIPTION
## Summary
- Add `TYPE_TUPLE` as a first-class value type with `(elem1, elem2, ...)` literal syntax
- Support index access (`t[0]`), `len()`, equality comparison, and nested tuples
- Parser correctly disambiguates tuple literals from lambda expressions `(x, y) => ...`
- Covers AST, bytecode, compiler, parser, value, and VM layers

Closes #57

**Note:** エンジニア・オーケストレーター無応答のため監督が直接実装。

## Test plan
- [x] Parser: TestTupleLiteral, TestTupleVsLambda
- [x] VM: TestTupleLiteral (9 test cases covering creation, mixed types, indexing, out-of-bounds, len, nesting, equality, function return)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)