### PR TITLE
gh-63: Web Playground with WASM execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ ehthumbs.db
 .calcium/
 *.ca.cache
 
+# Web Playground built artifacts (generated, not committed)
+/playground/calcium.wasm
+/playground/wasm_exec.js
+
 # madflow generated files
 prompts/
 madflow.toml

--- a/cmd/playground-build/main.go
+++ b/cmd/playground-build/main.go
@@ -1,0 +1,89 @@
+// Package main provides a build helper for the Calcium Web Playground.
+// It compiles the playground-wasm package to WebAssembly and copies the
+// required wasm_exec.js runtime file into the playground/ directory.
+//
+// Usage:
+//
+//	go run ./cmd/playground-build/
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	// Determine the project root (assumes this tool is run from the project root).
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("cannot determine working directory: %v", err)
+	}
+
+	playgroundDir := filepath.Join(cwd, "playground")
+	wasmOut := filepath.Join(playgroundDir, "calcium.wasm")
+
+	fmt.Println("Building Calcium Web Playground WASM...")
+
+	// Step 1: Build the WASM binary.
+	fmt.Printf("  Compiling cmd/playground-wasm -> %s\n", wasmOut)
+	cmd := exec.Command("go", "build", "-o", wasmOut, "./cmd/playground-wasm/")
+	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("WASM build failed: %v", err)
+	}
+	fmt.Println("  WASM build successful.")
+
+	// Step 2: Copy wasm_exec.js from the Go installation.
+	gorootCmd := exec.Command("go", "env", "GOROOT")
+	gorootOut, err := gorootCmd.Output()
+	if err != nil {
+		log.Fatalf("cannot determine GOROOT: %v", err)
+	}
+	goroot := strings.TrimSpace(string(gorootOut))
+	wasmExecSrc := filepath.Join(goroot, "misc", "wasm", "wasm_exec.js")
+	wasmExecDst := filepath.Join(playgroundDir, "wasm_exec.js")
+
+	fmt.Printf("  Copying wasm_exec.js from %s\n", wasmExecSrc)
+	if err := copyFile(wasmExecSrc, wasmExecDst); err != nil {
+		log.Fatalf("failed to copy wasm_exec.js: %v", err)
+	}
+	fmt.Println("  wasm_exec.js copied.")
+
+	fmt.Println()
+	fmt.Println("Build complete!")
+	fmt.Println()
+	fmt.Println("To start the playground server:")
+	fmt.Println("  go run ./cmd/playground-server/")
+	fmt.Println()
+	fmt.Println("Then open: http://localhost:8080")
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("create destination directory: %w", err)
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create destination: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy: %w", err)
+	}
+	return nil
+}

--- a/cmd/playground-server/main.go
+++ b/cmd/playground-server/main.go
@@ -1,0 +1,73 @@
+// Package main provides a simple HTTP server for the Calcium Web Playground.
+// It serves files from the playground/ directory and sets the correct
+// Content-Type and COOP/COEP headers required for SharedArrayBuffer (used by
+// some Go WASM runtimes).
+//
+// Usage:
+//
+//	go run ./cmd/playground-server/
+//
+// Then open http://localhost:8080 in your browser.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "HTTP listen address")
+	dir := flag.String("dir", "playground", "Directory to serve (default: playground/)")
+	flag.Parse()
+
+	// Resolve the playground directory relative to the binary location or cwd.
+	playgroundDir := *dir
+	if !filepath.IsAbs(playgroundDir) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("cannot determine working directory: %v", err)
+		}
+		playgroundDir = filepath.Join(cwd, playgroundDir)
+	}
+
+	if _, err := os.Stat(playgroundDir); os.IsNotExist(err) {
+		log.Fatalf("playground directory not found: %s", playgroundDir)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", addHeaders(http.FileServer(http.Dir(playgroundDir))))
+
+	fmt.Printf("Calcium Playground server listening on http://localhost%s\n", *addr)
+	fmt.Printf("Serving files from: %s\n", playgroundDir)
+	fmt.Println()
+	fmt.Println("To build the WASM runtime first, run:")
+	fmt.Println("  GOOS=js GOARCH=wasm go build -o playground/calcium.wasm ./cmd/playground-wasm/")
+	fmt.Println()
+	fmt.Println("Also copy wasm_exec.js from the Go installation:")
+	fmt.Println("  cp $(go env GOROOT)/misc/wasm/wasm_exec.js playground/")
+	fmt.Println()
+
+	if err := http.ListenAndServe(*addr, mux); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}
+
+// addHeaders wraps a handler to add the necessary HTTP headers for WASM.
+func addHeaders(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Required for SharedArrayBuffer in modern browsers.
+		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+		w.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
+
+		// Set correct MIME type for WASM.
+		if filepath.Ext(r.URL.Path) == ".wasm" {
+			w.Header().Set("Content-Type", "application/wasm")
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/cmd/playground-wasm/main.go
+++ b/cmd/playground-wasm/main.go
@@ -1,0 +1,42 @@
+//go:build js && wasm
+
+// Package main is the WebAssembly entry point for the Calcium Web Playground.
+// It exposes a `runCalcium(code)` JavaScript function that evaluates Calcium
+// source code and returns an object with `output` and `error` fields.
+package main
+
+import (
+	"syscall/js"
+
+	"github.com/ytnobody/calcium-lang/pkg/eval"
+)
+
+func runCalcium(_ js.Value, args []js.Value) any {
+	if len(args) == 0 {
+		return resultObj("", "runCalcium: no code provided")
+	}
+	source := args[0].String()
+	result := eval.Eval(source)
+
+	errMsg := ""
+	if result.Error != nil {
+		errMsg = result.Error.Error()
+	}
+	return resultObj(result.Output, errMsg)
+}
+
+// resultObj creates a plain JavaScript object with output and error fields.
+func resultObj(output, errMsg string) map[string]any {
+	return map[string]any{
+		"output": output,
+		"error":  errMsg,
+	}
+}
+
+func main() {
+	// Register the runCalcium function as a global JavaScript function.
+	js.Global().Set("runCalcium", js.FuncOf(runCalcium))
+
+	// Block forever to keep the WASM module alive.
+	select {}
+}

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -1,0 +1,78 @@
+// Package eval provides a high-level API for evaluating Calcium source code.
+// It is primarily used by the Web Playground WASM module and testing utilities.
+package eval
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ytnobody/calcium-lang/pkg/compiler"
+	"github.com/ytnobody/calcium-lang/pkg/lexer"
+	"github.com/ytnobody/calcium-lang/pkg/optimizer"
+	"github.com/ytnobody/calcium-lang/pkg/parser"
+	"github.com/ytnobody/calcium-lang/pkg/vm"
+)
+
+// Result holds the result of evaluating Calcium source code.
+type Result struct {
+	// Output contains the text written via print/println during execution.
+	Output string
+	// Error is non-nil if evaluation failed at any stage.
+	Error error
+}
+
+// Eval evaluates the given Calcium source code and returns a Result.
+// Output from print/println is captured and returned in Result.Output.
+// If w is non-nil, output is also written to w.
+func Eval(source string) Result {
+	var sb strings.Builder
+	err := evalInto(source, &sb)
+	return Result{
+		Output: sb.String(),
+		Error:  err,
+	}
+}
+
+// EvalInto evaluates the given Calcium source code and writes output to w.
+func EvalInto(source string, w io.Writer) error {
+	return evalInto(source, w)
+}
+
+func evalInto(source string, w io.Writer) error {
+	// Parse
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		return fmt.Errorf("parse error:\n%s", strings.Join(p.Errors(), "\n"))
+	}
+
+	// Optimize AST
+	opt := optimizer.New(optimizer.O1)
+	program = opt.OptimizeAST(program)
+
+	// Compile
+	c := compiler.New()
+	c.SetInput(source)
+	c.SetFileName("<playground>")
+	if err := c.Compile(program); err != nil {
+		return fmt.Errorf("compile error:\n%s", err.Error())
+	}
+
+	// Optimize bytecode
+	instructions := opt.OptimizeBytecode(c.Bytecode().Instructions)
+
+	// Run
+	machine := vm.New(c.Constants())
+	machine.SetSourceMap(c.SourceMap())
+	machine.SetSourceInput(source)
+	machine.SetOutput(w)
+
+	if err := machine.Run(instructions); err != nil {
+		return fmt.Errorf("runtime error:\n%s", err.Error())
+	}
+
+	return nil
+}

--- a/pkg/eval/eval_test.go
+++ b/pkg/eval/eval_test.go
@@ -1,0 +1,83 @@
+package eval_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ytnobody/calcium-lang/pkg/eval"
+)
+
+func TestEval_HelloWorld(t *testing.T) {
+	src := `use core.io!;
+"Hello, World!" !> io.say;`
+	result := eval.Eval(src)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if !strings.Contains(result.Output, "Hello, World!") {
+		t.Errorf("expected output to contain 'Hello, World!', got %q", result.Output)
+	}
+}
+
+func TestEval_Print(t *testing.T) {
+	src := `use core.io!;
+io.print("foo");
+io.print("bar");`
+	result := eval.Eval(src)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.Output != "foobar" {
+		t.Errorf("expected 'foobar', got %q", result.Output)
+	}
+}
+
+func TestEval_Arithmetic(t *testing.T) {
+	src := `use core.io!;
+x = 6 * 7;
+to_string(x) !> io.say;`
+	result := eval.Eval(src)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if !strings.Contains(result.Output, "42") {
+		t.Errorf("expected output to contain '42', got %q", result.Output)
+	}
+}
+
+func TestEval_ParseError(t *testing.T) {
+	src := `use core.io!;
+this is invalid !!!`
+	result := eval.Eval(src)
+	if result.Error == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestEval_MultipleLines(t *testing.T) {
+	src := `use core.io!;
+io.println("line1");
+io.println("line2");
+io.println("line3");`
+	result := eval.Eval(src)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	lines := strings.Split(strings.TrimRight(result.Output, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d: %q", len(lines), result.Output)
+	}
+}
+
+func TestEvalInto_WritesToWriter(t *testing.T) {
+	var sb strings.Builder
+	src := `use core.io!;
+"written to writer" !> io.say;`
+	err := eval.EvalInto(src, &sb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sb.String(), "written to writer") {
+		t.Errorf("expected writer to contain 'written to writer', got %q", sb.String())
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"strings"
@@ -126,6 +127,9 @@ type VM struct {
 
 	// Source input for showing source lines in error messages
 	sourceInput string
+
+	// Output writer for print/println (default: os.Stdout)
+	output io.Writer
 }
 
 // SetSourcePath sets the source file path for external module resolution
@@ -141,6 +145,20 @@ func (vm *VM) SetSourceMap(sm *bytecode.SourceMap) {
 // SetSourceInput sets the source code text for error messages
 func (vm *VM) SetSourceInput(input string) {
 	vm.sourceInput = input
+}
+
+// SetOutput sets the writer used for print/println output.
+// If not set, os.Stdout is used by default.
+func (vm *VM) SetOutput(w io.Writer) {
+	vm.output = w
+}
+
+// getOutput returns the output writer, defaulting to os.Stdout.
+func (vm *VM) getOutput() io.Writer {
+	if vm.output != nil {
+		return vm.output
+	}
+	return os.Stdout
 }
 
 // SetRunOptions sets the run options for the VM
@@ -2705,24 +2723,26 @@ func builtinHashMerge(args ...value.Value) value.Value {
 
 // print - prints values without newline (core.io!)
 func (vm *VM) builtinPrint(args ...value.Value) value.Value {
+	w := vm.getOutput()
 	for i, arg := range args {
 		if i > 0 {
-			fmt.Print(" ")
+			fmt.Fprint(w, " ")
 		}
-		fmt.Print(arg.String())
+		fmt.Fprint(w, arg.String())
 	}
 	return value.Null()
 }
 
 // println - prints values with newline (core.io!)
 func (vm *VM) builtinPrintln(args ...value.Value) value.Value {
+	w := vm.getOutput()
 	for i, arg := range args {
 		if i > 0 {
-			fmt.Print(" ")
+			fmt.Fprint(w, " ")
 		}
-		fmt.Print(arg.String())
+		fmt.Fprint(w, arg.String())
 	}
-	fmt.Println()
+	fmt.Fprintln(w)
 	return value.Null()
 }
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,677 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calcium Playground</title>
+  <!-- CodeMirror for syntax highlighting -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/dracula.min.css" />
+  <style>
+    :root {
+      --bg: #1e1e2e;
+      --surface: #181825;
+      --surface2: #313244;
+      --accent: #cba6f7;
+      --accent2: #89b4fa;
+      --text: #cdd6f4;
+      --subtext: #a6adc8;
+      --green: #a6e3a1;
+      --red: #f38ba8;
+      --yellow: #f9e2af;
+      --border: #45475a;
+      --radius: 8px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 12px 20px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-shrink: 0;
+    }
+
+    .logo {
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: var(--accent);
+      letter-spacing: -0.5px;
+    }
+
+    .logo span {
+      color: var(--accent2);
+    }
+
+    .tagline {
+      color: var(--subtext);
+      font-size: 0.875rem;
+    }
+
+    .header-actions {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 16px;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: all 0.15s ease;
+      text-decoration: none;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: var(--surface);
+    }
+
+    .btn-primary:hover:not(:disabled) {
+      filter: brightness(1.1);
+    }
+
+    .btn-secondary {
+      background: var(--surface2);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover:not(:disabled) {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    .btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 20px;
+      font-size: 0.75rem;
+      font-weight: 500;
+      background: var(--surface2);
+      color: var(--subtext);
+      border: 1px solid var(--border);
+    }
+
+    .status-badge.ready {
+      color: var(--green);
+      border-color: var(--green);
+    }
+
+    .status-badge.loading {
+      color: var(--yellow);
+      border-color: var(--yellow);
+    }
+
+    .status-badge.error {
+      color: var(--red);
+      border-color: var(--red);
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .loading-spinner {
+      width: 8px;
+      height: 8px;
+      border: 2px solid currentColor;
+      border-top-color: transparent;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .main-layout {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+      gap: 0;
+    }
+
+    .pane {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      min-width: 0;
+    }
+
+    .pane-header {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 8px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--subtext);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      flex-shrink: 0;
+    }
+
+    .divider {
+      width: 1px;
+      background: var(--border);
+      flex-shrink: 0;
+    }
+
+    .editor-pane {
+      flex: 1.2;
+    }
+
+    .output-pane {
+      flex: 0.8;
+    }
+
+    /* CodeMirror overrides */
+    .CodeMirror {
+      height: 100%;
+      font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 14px;
+      line-height: 1.6;
+      background: var(--bg) !important;
+    }
+
+    .CodeMirror-scroll {
+      padding: 8px 0;
+    }
+
+    .cm-wrapper {
+      flex: 1;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .output-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px;
+      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-size: 13px;
+      line-height: 1.7;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .output-content.empty {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--subtext);
+      font-family: inherit;
+      font-size: 0.875rem;
+      font-style: italic;
+    }
+
+    .output-error {
+      color: var(--red);
+    }
+
+    .output-success {
+      color: var(--text);
+    }
+
+    .examples-bar {
+      background: var(--surface);
+      border-top: 1px solid var(--border);
+      padding: 8px 16px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      overflow-x: auto;
+      flex-shrink: 0;
+      scrollbar-width: none;
+    }
+
+    .examples-bar::-webkit-scrollbar {
+      display: none;
+    }
+
+    .examples-label {
+      font-size: 0.75rem;
+      color: var(--subtext);
+      white-space: nowrap;
+      margin-right: 4px;
+    }
+
+    .example-chip {
+      padding: 4px 10px;
+      border-radius: 4px;
+      background: var(--surface2);
+      color: var(--subtext);
+      font-size: 0.75rem;
+      cursor: pointer;
+      border: 1px solid var(--border);
+      white-space: nowrap;
+      transition: all 0.15s;
+    }
+
+    .example-chip:hover {
+      border-color: var(--accent2);
+      color: var(--accent2);
+    }
+
+    .shortcut-hint {
+      font-size: 0.7rem;
+      color: var(--subtext);
+      opacity: 0.6;
+    }
+
+    kbd {
+      display: inline-block;
+      padding: 1px 5px;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      font-family: inherit;
+      font-size: 0.7rem;
+      background: var(--surface2);
+    }
+
+    .run-time {
+      color: var(--subtext);
+      font-size: 0.7rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">Ca<span>lcium</span></div>
+    <div class="tagline">Playground</div>
+    <div class="header-actions">
+      <span id="wasmStatus" class="status-badge loading">
+        <span class="loading-spinner"></span>
+        Loading runtime...
+      </span>
+      <button id="clearBtn" class="btn btn-secondary" onclick="clearOutput()">Clear</button>
+      <button id="runBtn" class="btn btn-primary" onclick="runCode()" disabled>
+        ▶ Run
+        <span class="shortcut-hint"><kbd>Ctrl</kbd>+<kbd>Enter</kbd></span>
+      </button>
+    </div>
+  </header>
+
+  <div class="main-layout">
+    <!-- Editor pane -->
+    <div class="pane editor-pane">
+      <div class="pane-header">
+        <span>Editor</span>
+        <span class="shortcut-hint">calcium</span>
+      </div>
+      <div class="cm-wrapper">
+        <textarea id="codeInput"></textarea>
+      </div>
+      <div class="examples-bar">
+        <span class="examples-label">Examples:</span>
+        <button class="example-chip" onclick="loadExample('hello')">Hello World</button>
+        <button class="example-chip" onclick="loadExample('fibonacci')">Fibonacci</button>
+        <button class="example-chip" onclick="loadExample('pattern')">Pattern Matching</button>
+        <button class="example-chip" onclick="loadExample('adt')">ADT</button>
+        <button class="example-chip" onclick="loadExample('higher-order')">Higher Order</button>
+        <button class="example-chip" onclick="loadExample('pipeline')">Pipeline</button>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <!-- Output pane -->
+    <div class="pane output-pane">
+      <div class="pane-header">
+        <span>Output</span>
+        <span id="runTime" class="run-time"></span>
+      </div>
+      <div id="outputContent" class="output-content empty">
+        Run your code to see output here
+      </div>
+    </div>
+  </div>
+
+  <!-- CodeMirror -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/closebrackets.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/matchbrackets.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/comment/comment.min.js"></script>
+
+  <script>
+    // ============================================================
+    // Example code snippets
+    // ============================================================
+    const EXAMPLES = {
+      hello: `use core.io!;
+
+"Hello, Calcium!" !> io.say;
+
+name = "World";
+concat("Hello, ", name, "!") !> io.say;`,
+
+      fibonacci: `use core.io!;
+
+func fib(n) =
+  if n <= 1 then n
+  else fib(n - 1) + fib(n - 2);
+
+// Print first 10 Fibonacci numbers
+func print_fibs(i) =
+  if i > 10 then null
+  else {
+    concat("fib(", to_string(i), ") = ", to_string(fib(i))) !> io.say;
+    print_fibs(i + 1)
+  };
+
+print_fibs(0);`,
+
+      pattern: `use core.io!;
+
+// Pattern matching example
+func describe(x) = match x
+  0     => "zero"
+  1     => "one"
+  n     => concat("number: ", to_string(n));
+
+describe(0) !> io.say;
+describe(1) !> io.say;
+describe(42) !> io.say;
+
+// Matching on lists
+func list_info(lst) = match lst
+  []       => "empty list"
+  [x]      => concat("single element: ", to_string(x))
+  [x, ..rest] => concat("head: ", to_string(x), ", tail length: ", to_string(len(rest)));
+
+list_info([]) !> io.say;
+list_info([42]) !> io.say;
+list_info([1, 2, 3, 4]) !> io.say;`,
+
+      adt: `use core.io!;
+
+// Algebraic Data Types
+type Shape =
+  Circle(radius)
+  | Rectangle(width, height)
+  | Triangle(base, height);
+
+func area(shape) = match shape
+  Circle(r)          => 3.14159 * r * r
+  Rectangle(w, h)    => w * h
+  Triangle(b, h)     => 0.5 * b * h;
+
+func describe(shape) = match shape
+  Circle(r)          => concat("Circle(r=", to_string(r), ")")
+  Rectangle(w, h)    => concat("Rectangle(", to_string(w), "x", to_string(h), ")")
+  Triangle(b, h)     => concat("Triangle(b=", to_string(b), ", h=", to_string(h), ")");
+
+shapes = [Circle(5.0), Rectangle(4.0, 6.0), Triangle(3.0, 8.0)];
+
+func print_shapes(lst) = match lst
+  [] => null
+  [s, ..rest] => {
+    concat(describe(s), " -> area = ", to_string(area(s))) !> io.say;
+    print_shapes(rest)
+  };
+
+print_shapes(shapes);`,
+
+      'higher-order': `use core.io!;
+
+// Higher-order functions
+numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+// Map: double each number
+doubled = map(numbers, fn(x) => x * 2);
+concat("Doubled: ", to_string(doubled)) !> io.say;
+
+// Filter: keep even numbers
+evens = filter(numbers, fn(x) => x % 2 == 0);
+concat("Evens: ", to_string(evens)) !> io.say;
+
+// Reduce: sum all numbers
+total = reduce(numbers, 0, fn(acc, x) => acc + x);
+concat("Sum: ", to_string(total)) !> io.say;
+
+// Compose operations
+result = numbers
+  |> filter(_, fn(x) => x % 2 != 0)
+  |> map(_, fn(x) => x * x)
+  |> reduce(_, 0, fn(acc, x) => acc + x);
+concat("Sum of squares of odds: ", to_string(result)) !> io.say;`,
+
+      pipeline: `use core.io!;
+
+// Pipeline operator |> and effect operator !>
+words = ["calcium", "is", "functional", "and", "fun"];
+
+// Using pipeline to transform data
+result = words
+  |> map(_, fn(w) => to_upper(w))
+  |> filter(_, fn(w) => len(w) > 2);
+
+result !> io.say;
+
+// Chaining with effect operator
+"Pipeline and effects in Calcium:" !> io.say;
+42 |> to_string |> fn(s) => concat("The answer is: ", s) |> io.say;`,
+    };
+
+    // ============================================================
+    // CodeMirror editor setup
+    // ============================================================
+    let editor;
+
+    function initEditor() {
+      // Simple Calcium syntax highlighting mode (based on Haskell-like syntax)
+      CodeMirror.defineMode('calcium', function() {
+        const keywords = /^(use|fn|func|if|then|else|match|type|let|in|and|or|not|true|false|null)\b/;
+        const operators = /^[+\-*\/%|><=!&^~]+/;
+        const builtinFuncs = /^(map|filter|reduce|len|concat|to_string|to_upper|to_lower|to_int|to_float|print|println|say|push|pop|keys|values|type_of)\b/;
+
+        return {
+          token: function(stream) {
+            if (stream.eatSpace()) return null;
+
+            // Comments
+            if (stream.match('//')) {
+              stream.skipToEnd();
+              return 'comment';
+            }
+
+            // Strings
+            if (stream.match('"')) {
+              while (!stream.eol()) {
+                if (stream.next() === '"') break;
+              }
+              return 'string';
+            }
+
+            // Numbers
+            if (stream.match(/^-?[0-9]+(\.[0-9]+)?/)) return 'number';
+
+            // Keywords
+            if (stream.match(keywords)) return 'keyword';
+
+            // Builtin functions
+            if (stream.match(builtinFuncs)) return 'builtin';
+
+            // Types (capitalized identifiers)
+            if (stream.match(/^[A-Z][a-zA-Z0-9_]*/)) return 'type';
+
+            // Identifiers
+            if (stream.match(/^[a-z_][a-zA-Z0-9_]*/)) return 'variable';
+
+            // Operators
+            if (stream.match(operators)) return 'operator';
+
+            stream.next();
+            return null;
+          }
+        };
+      });
+
+      editor = CodeMirror.fromTextArea(document.getElementById('codeInput'), {
+        mode: 'calcium',
+        theme: 'dracula',
+        lineNumbers: true,
+        autoCloseBrackets: true,
+        matchBrackets: true,
+        tabSize: 2,
+        indentWithTabs: false,
+        lineWrapping: false,
+        extraKeys: {
+          'Ctrl-Enter': runCode,
+          'Cmd-Enter': runCode,
+          'Ctrl-/': 'toggleComment',
+        },
+      });
+
+      // Set the default example
+      editor.setValue(EXAMPLES['hello']);
+    }
+
+    // ============================================================
+    // WASM loading
+    // ============================================================
+    async function loadWasm() {
+      const statusEl = document.getElementById('wasmStatus');
+      try {
+        const go = new Go();
+        const result = await WebAssembly.instantiateStreaming(
+          fetch('calcium.wasm'),
+          go.importObject
+        );
+        go.run(result.instance);
+        setStatus('ready', '● Ready');
+        document.getElementById('runBtn').disabled = false;
+      } catch (err) {
+        console.error('Failed to load WASM:', err);
+        setStatus('error', '✗ Runtime unavailable');
+        // Still allow editing but show error
+        showBuildInstructions();
+      }
+    }
+
+    function setStatus(type, text) {
+      const el = document.getElementById('wasmStatus');
+      el.className = 'status-badge ' + type;
+      el.innerHTML = type === 'loading'
+        ? '<span class="loading-spinner"></span> ' + text
+        : text;
+    }
+
+    function showBuildInstructions() {
+      const output = document.getElementById('outputContent');
+      output.className = 'output-content output-error';
+      output.textContent =
+        'WebAssembly runtime not found.\n\n' +
+        'To build the runtime, run:\n\n' +
+        '  GOOS=js GOARCH=wasm go build -o playground/calcium.wasm ./cmd/playground-wasm/\n\n' +
+        'Then serve this directory with an HTTP server:\n\n' +
+        '  go run ./cmd/playground-server/\n\n' +
+        'Or use any static file server.';
+      document.getElementById('runBtn').disabled = false;
+      document.getElementById('runBtn').textContent = '▶ Run (demo mode)';
+    }
+
+    // ============================================================
+    // Run code
+    // ============================================================
+    function runCode() {
+      const code = editor.getValue();
+      const output = document.getElementById('outputContent');
+      const runTimeEl = document.getElementById('runTime');
+
+      if (typeof runCalcium === 'undefined') {
+        output.className = 'output-content output-error';
+        output.textContent = 'Error: WebAssembly runtime not loaded.\nBuild calcium.wasm first.';
+        return;
+      }
+
+      const start = performance.now();
+      let result;
+      try {
+        result = runCalcium(code);
+      } catch (err) {
+        output.className = 'output-content output-error';
+        output.textContent = 'Internal error: ' + err.message;
+        return;
+      }
+      const elapsed = (performance.now() - start).toFixed(1);
+      runTimeEl.textContent = elapsed + 'ms';
+
+      if (result.error && result.error.length > 0) {
+        output.className = 'output-content output-error';
+        output.textContent = result.error;
+      } else if (result.output.length === 0) {
+        output.className = 'output-content empty';
+        output.textContent = '(no output)';
+      } else {
+        output.className = 'output-content output-success';
+        output.textContent = result.output;
+      }
+    }
+
+    function clearOutput() {
+      const output = document.getElementById('outputContent');
+      output.className = 'output-content empty';
+      output.textContent = 'Run your code to see output here';
+      document.getElementById('runTime').textContent = '';
+    }
+
+    function loadExample(name) {
+      if (EXAMPLES[name]) {
+        editor.setValue(EXAMPLES[name]);
+        editor.focus();
+        clearOutput();
+      }
+    }
+
+    // ============================================================
+    // Init
+    // ============================================================
+    document.addEventListener('DOMContentLoaded', function() {
+      initEditor();
+      loadWasm();
+    });
+  </script>
+
+  <!-- Go WASM runtime support -->
+  <script src="wasm_exec.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Issue: gh-63

## 概要

ブラウザ上で Calcium コードを実行できる Web Playground を実装しました。Go の WebAssembly (WASM) 機能を活用しています。

## 変更内容

### 新規追加

| ファイル | 説明 |
|--------|------|
| `pkg/eval/eval.go` | Calcium コードを実行する高レベル API (`Eval` / `EvalInto`) |
| `pkg/eval/eval_test.go` | eval パッケージのテスト |
| `cmd/playground-wasm/main.go` | WASM バイナリのエントリポイント。`runCalcium(code)` を JS に公開 |
| `cmd/playground-server/main.go` | ローカル開発用 HTTP サーバー |
| `cmd/playground-build/main.go` | WASM ビルドヘルパー (Go プログラム) |
| `playground/index.html` | Web Playground UI (CodeMirror エディタ、出力パネル、6 つのサンプルコード) |

### 変更

| ファイル | 説明 |
|--------|------|
| `pkg/vm/vm.go` | VM に `SetOutput(io.Writer)` を追加。print/println が任意の Writer に出力可能 |
| `.gitignore` | WASM ビルド成果物を除外 |

## アーキテクチャ

```
ブラウザ
  └── playground/index.html
        ├── CodeMirror エディタ
        ├── calcium.wasm  (GOOS=js GOARCH=wasm でビルド)
        │     └── cmd/playground-wasm/main.go
        │           └── pkg/eval  →  lexer → parser → compiler → optimizer → vm
        └── wasm_exec.js  (Go 標準ライブラリから)
```

## 使い方

```bash
# 1. WASM バイナリをビルド
go run ./cmd/playground-build/

# 2. サーバーを起動
go run ./cmd/playground-server/

# 3. ブラウザで開く
# http://localhost:8080
```

## 後方互換性

VM の `SetOutput` は省略可能です。設定しない場合は従来どおり `os.Stdout` に出力されます。

## テスト結果

全テスト通過確認済み。