### PR TITLE
gh-99: pkg/bone のテストカバレッジを 16.2% → 81.7% に向上

### DIFF
--- a/pkg/bone/bone_test.go
+++ b/pkg/bone/bone_test.go
@@ -346,11 +346,11 @@ func TestFindProjectRoot_NotFound(t *testing.T) {
 
 func TestParseModuleSpec(t *testing.T) {
 	tests := []struct {
-		spec          string
-		wantAuthor    string
-		wantName      string
-		wantVersion   string
-		wantErr       bool
+		spec        string
+		wantAuthor  string
+		wantName    string
+		wantVersion string
+		wantErr     bool
 	}{
 		{"alice/mymod", "alice", "mymod", "", false},
 		{"Alice/MyMod", "alice", "mymod", "", false},
@@ -1054,11 +1054,11 @@ func TestInit_WithStdin(t *testing.T) {
 	// Write stdin input: module name, author, description, license, keywords
 	go func() {
 		defer w.Close()
-		fmt.Fprintf(w, "\n")         // accept default module name
-		fmt.Fprintf(w, "testauthor\n") // author
+		fmt.Fprintf(w, "\n")              // accept default module name
+		fmt.Fprintf(w, "testauthor\n")    // author
 		fmt.Fprintf(w, "A test module\n") // description
-		fmt.Fprintf(w, "Apache-2.0\n")   // license
-		fmt.Fprintf(w, "test,module\n")  // keywords
+		fmt.Fprintf(w, "Apache-2.0\n")    // license
+		fmt.Fprintf(w, "test,module\n")   // keywords
 	}()
 
 	err = Init("")


### PR DESCRIPTION
Issue: gh-99

## 変更内容

pkg/bone パッケージのテストカバレッジを 16.2% から 81.7% に向上させました。

### 追加したテスト (pkg/bone/bone_test.go)

- **config.go**: LoadBoneConfig, SaveBoneConfig, GetRegistryURL, SetConfig, GetConfig, ShowConfig
- **Dependency.UnmarshalTOML**: 文字列形式・マップ形式のデコード
- **config.go**: LoadMeta, SaveMeta, LoadLockFile, SaveLockFile, FindProjectRoot
- **registry.go**: ParseModuleSpec, GetIndexPath, FetchMeta, FetchVersion, FetchFile（モックHTTPサーバー使用）
- **add.go**: updateLockEntry, Add（ローカル・グローバル両方）
- **install.go**: Install（モックサーバー使用）
- **list.go**: List
- **remove.go**: Remove
- **update.go**: Update（各エラーケース）
- **init.go**: Init（os.Pipe() でstdinをシミュレート）
- **version.go**: VersionConstraint.String()