### PR TITLE
gh-104: improve pkg/parser test coverage from 51.9% to 83.2%

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1777,12 +1777,12 @@ func TestNoPrefixParseFnErrors(t *testing.T) {
 		input       string
 		expectError bool
 	}{
-		{`= 5;`, true},          // ASSIGN
-		{`};`, true},            // RBRACE
-		{`];`, true},            // RBRACKET
-		{`);`, true},            // RPAREN
-		{`, 5;`, true},          // COMMA
-		{`;;`, true},            // SEMICOLON
+		{`= 5;`, true}, // ASSIGN
+		{`};`, true},   // RBRACE
+		{`];`, true},   // RBRACKET
+		{`);`, true},   // RPAREN
+		{`, 5;`, true}, // COMMA
+		{`;;`, true},   // SEMICOLON
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add comprehensive tests to improve `pkg/parser` test coverage from 51.9% to 83.2%
- Cover 30+ previously untested parser functions including type declarations, namespace declarations, do expressions, effect handling, destructuring, block-body lambdas, regex/float/interpolated string literals, and various error paths
- All tests use table-driven patterns where appropriate

## Test plan
- [x] All tests pass: `go test ./pkg/parser/... -v -cover`
- [x] Coverage exceeds 75% target (achieved 83.2%)
- [x] Linter passes: `golangci-lint run ./pkg/parser/...`
- [x] No existing tests broken

Generated with [Claude Code](https://claude.com/claude-code)