### PR TITLE
gh-118: develop ブランチ作成と main マージ時の自動リリース整備

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,53 @@
+name: Auto Release on Merge to Main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Latest tag: $LATEST_TAG"
+
+      - name: Bump patch version
+        id: next_tag
+        run: |
+          LATEST="${{ steps.latest_tag.outputs.tag }}"
+          # Strip leading 'v'
+          VERSION="${LATEST#v}"
+          # Split into major, minor, patch
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          # Increment patch
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT_TAG="v${MAJOR}.${MINOR}.${NEXT_PATCH}"
+          echo "tag=$NEXT_TAG" >> $GITHUB_OUTPUT
+          echo "Next tag: $NEXT_TAG"
+
+      - name: Create and push tag
+        run: |
+          NEXT_TAG="${{ steps.next_tag.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$NEXT_TAG"
+          git push origin "$NEXT_TAG"
+          echo "Created and pushed tag: $NEXT_TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   test:


### PR DESCRIPTION
Issue: gh-118

## 変更内容

### developブランチの作成
- リモートに `develop` ブランチを作成しました
- 今後の開発は `develop` ブランチで行い、`main` へのマージでリリースが自動実行されます

### ワークフロー変更

#### `.github/workflows/ci.yml`
- CIが `develop` ブランチへの push および `develop` への PR でも実行されるよう更新

#### `.github/workflows/auto-release.yml` (新規)
- `main` ブランチへの push をトリガーとして自動実行
- 最新のセマンティックバージョンタグを取得し、パッチバージョンをインクリメント
- 新しいタグを自動作成・push
- 既存の `release.yml` がタグ push をトリガーに GoReleaser でリリースを実行

## リリースフロー

```
develop ブランチで開発
  ↓ PR を main にマージ
auto-release.yml が起動 → パッチバージョンのタグを自動作成
  ↓ タグ push
release.yml が起動 → GoReleaser でリリース成果物を生成・公開
```