### PR TITLE
gh-122: Implement regex match operator ~

### DIFF
--- a/pkg/bytecode/bytecode.go
+++ b/pkg/bytecode/bytecode.go
@@ -118,6 +118,9 @@ const (
 
 	// Function overloading
 	OpAddOverload // Pop new closure (TOS) and existing closure/overloaded (TOS-1), push overloaded closure
+
+	// Regex match
+	OpRegexMatch // left ~ right: match string against regex
 )
 
 // Definition describes an opcode
@@ -220,6 +223,9 @@ var definitions = map[OpCode]*Definition{
 
 	// Function overloading
 	OpAddOverload: {"OpAddOverload", []int{}}, // No operands: pops new closure and existing, pushes overloaded
+
+	// Regex match
+	OpRegexMatch: {"OpRegexMatch", []int{}}, // No operands: pops regex (TOS) and string (TOS-1), pushes bool
 }
 
 // Lookup returns the definition for an opcode

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -979,6 +979,8 @@ func (c *Compiler) Compile(node ast.Node) error {
 			c.emit(bytecode.OpLessEqual)
 		case ">=":
 			c.emit(bytecode.OpGreaterEqual)
+		case "~":
+			c.emit(bytecode.OpRegexMatch)
 		default:
 			return c.newCompileError(node.Token, fmt.Sprintf("unknown infix operator '%s'", node.Operator))
 		}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -185,6 +185,8 @@ func (l *Lexer) NextToken() token.Token {
 			l.interpBraceDepth++
 		}
 		tok = newToken(token.LBRACE, l.ch, tok.Line, tok.Column)
+	case '~':
+		tok = newToken(token.TILDE, l.ch, tok.Line, tok.Column)
 	case '?':
 		tok = newToken(token.QUESTION, l.ch, tok.Line, tok.Column)
 	case '}':

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -56,6 +56,7 @@ var precedences = map[token.TokenType]int{
 	token.SPREAD:      SPREAD,
 	token.QUESTION:    SPREAD, // ? for constraint check (same precedence as spread)
 	token.ARROW:       LAMBDA, // => for lambda
+	token.TILDE:       EQUALS, // ~ for regex match
 }
 
 type (
@@ -141,6 +142,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.QUESTION, p.parseConstraintCheckExpression)
 	p.registerInfix(token.EFFECT_END, p.parseEffectHandleExpression)
 	p.registerInfix(token.ARROW, p.parseLambdaFromIdent)
+	p.registerInfix(token.TILDE, p.parseInfixExpression)
 
 	// Read two tokens, so curToken and peekToken are both set
 	p.nextToken()

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -54,6 +54,9 @@ const (
 	EFFECT_PIPE TokenType = "!>"
 	EFFECT_END  TokenType = "!?"
 
+	// Regex match
+	TILDE TokenType = "~"
+
 	// Arrow
 	ARROW TokenType = "=>"
 

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -630,6 +630,18 @@ func (vm *VM) executeOpcode(op bytecode.OpCode) error {
 		left := vm.pop()
 		vm.push(value.Bool(!left.Equals(right)))
 
+	case bytecode.OpRegexMatch:
+		right := vm.pop()
+		left := vm.pop()
+		if right.Type != value.TYPE_REGEX {
+			return fmt.Errorf("type error: right operand of '~' must be a regex, got %s", right.Type)
+		}
+		if left.Type != value.TYPE_STRING {
+			return fmt.Errorf("type error: left operand of '~' must be a string, got %s", left.Type)
+		}
+		re := right.AsRegex()
+		vm.push(value.Bool(re.Re.MatchString(left.AsString())))
+
 	case bytecode.OpLessThan:
 		err := vm.executeComparison(op)
 		if err != nil {

--- a/tests/regex_match.test.ca
+++ b/tests/regex_match.test.ca
@@ -1,0 +1,32 @@
+// Regex Match Operator Test
+use core.io!;
+use test;
+
+io.println("# Regex Match Operator Tests");
+
+// === Basic regex match ===
+test.new()
+    |> test.plan(16)
+    // Basic match
+    |> test.ok("hello matches /hello/", "hello" ~ /hello/)
+    |> test.ok("hello123 matches /[a-z]+[0-9]+/", "hello123" ~ /[a-z]+[0-9]+/)
+    |> test.is("world does not match /hello/", "world" ~ /hello/, false)
+    // Integer pattern (from issue example)
+    |> test.ok("123 matches integer pattern", "123" ~ /^-?[1-9][0-9]*$/)
+    |> test.ok("-456 matches integer pattern", "-456" ~ /^-?[1-9][0-9]*$/)
+    |> test.is("0 does not match integer pattern", "0" ~ /^-?[1-9][0-9]*$/, false)
+    |> test.is("3.14 does not match integer pattern", "3.14" ~ /^-?[1-9][0-9]*$/, false)
+    |> test.is("abc does not match integer pattern", "abc" ~ /^-?[1-9][0-9]*$/, false)
+    // Case-insensitive flag
+    |> test.ok("HELLO matches /hello/i", "HELLO" ~ /hello/i)
+    |> test.ok("Hello matches /hello/i", "Hello" ~ /hello/i)
+    |> test.is("world does not match /hello/i", "world" ~ /hello/i, false)
+    // Email pattern
+    |> test.ok("valid email matches", "user@example.com" ~ /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/)
+    |> test.is("invalid email does not match", "not-an-email" ~ /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, false)
+    // Empty string
+    |> test.ok("empty string matches empty pattern", "" ~ /^$/)
+    |> test.is("empty string does not match non-empty", "" ~ /[a-z]+/, false)
+    // Constraint using ~ operator
+    |> test.ok("42 matches digit pattern", "42" ~ /^\d+$/)
+    |> test.done();


### PR DESCRIPTION
## Summary

Implements the regex match operator `~` for calcium-lang (issue gh-122).

### Usage

```calcium
// Basic usage
"hello" ~ /hello/      // true
"world" ~ /hello/      // false

// Case-insensitive flag
"HELLO" ~ /hello/i     // true

// In constraints (from issue example)
constraint Int(n) = n ~ /^-?[1-9][0-9]*$/;
Int("123")   // true
Int("abc")   // false
```

### Implementation

- **token**: Added `TILDE` token type (`~`)
- **lexer**: Lex `~` as `TILDE` token
- **parser**: Register `~` as infix operator with `EQUALS` precedence
- **bytecode**: Added `OpRegexMatch` opcode
- **compiler**: Emit `OpRegexMatch` for the `~` operator
- **vm**: Execute `OpRegexMatch` — left operand must be string, right must be regex, returns bool
- **tests**: 16 test cases covering basic match, integer patterns, case-insensitive flags, email patterns, and edge cases

Issue: gh-122