### PR TITLE
gh-120: implement primitive type constraints

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -256,7 +256,14 @@ func New() *Compiler {
 	}
 
 	// Define built-in functions
-	builtins := []string{"len", "concat", "to_string", "get", "has", "head", "tail", "push", "range", "map", "filter", "reduce", "keys", "values", "hash_set", "hash_merge"}
+	builtins := []string{
+		"len", "concat", "to_string", "get", "has", "head", "tail", "push", "range",
+		"map", "filter", "reduce",
+		"keys", "values", "hash_set", "hash_merge",
+		// Primitive type constraint checkers (usable as Name? in constraint expressions)
+		"Int", "Float", "String", "Bool", "Array", "Hash", "Tuple", "Null",
+		"Function", "Number",
+	}
 	for i, name := range builtins {
 		symbolTable.DefineBuiltin(i, name)
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -308,6 +308,17 @@ func (vm *VM) initBuiltins() {
 		{Name: "values", Fn: builtinValues},
 		{Name: "hash_set", Fn: builtinHashSet},
 		{Name: "hash_merge", Fn: builtinHashMerge},
+		// Primitive type constraint checkers
+		{Name: "Int", Fn: builtinIsInt},
+		{Name: "Float", Fn: builtinIsFloat},
+		{Name: "String", Fn: builtinIsString},
+		{Name: "Bool", Fn: builtinIsBool},
+		{Name: "Array", Fn: builtinIsArray},
+		{Name: "Hash", Fn: builtinIsHash},
+		{Name: "Tuple", Fn: builtinIsTuple},
+		{Name: "Null", Fn: builtinIsNull},
+		{Name: "Function", Fn: builtinIsFunction},
+		{Name: "Number", Fn: builtinIsNumber},
 	}
 }
 
@@ -3917,4 +3928,101 @@ func mapKeys(m map[string]value.Value) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// builtinIsInt checks whether the argument is an integer value.
+// Used as a primitive constraint: 42 |> Int?
+func builtinIsInt(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_INT)
+}
+
+// builtinIsFloat checks whether the argument is a float value.
+// Used as a primitive constraint: 3.14 |> Float?
+func builtinIsFloat(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_FLOAT)
+}
+
+// builtinIsString checks whether the argument is a string value.
+// Used as a primitive constraint: "hello" |> String?
+func builtinIsString(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_STRING)
+}
+
+// builtinIsBool checks whether the argument is a boolean value.
+// Used as a primitive constraint: true |> Bool?
+func builtinIsBool(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_BOOL)
+}
+
+// builtinIsArray checks whether the argument is an array value.
+// Used as a primitive constraint: [1, 2, 3] |> Array?
+func builtinIsArray(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_ARRAY)
+}
+
+// builtinIsHash checks whether the argument is a hash (map) value.
+// Used as a primitive constraint: {a: 1} |> Hash?
+func builtinIsHash(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_HASH)
+}
+
+// builtinIsTuple checks whether the argument is a tuple value.
+// Used as a primitive constraint: (1, 2) |> Tuple?
+func builtinIsTuple(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_TUPLE)
+}
+
+// builtinIsNull checks whether the argument is null.
+// Used as a primitive constraint: null |> Null?
+func builtinIsNull(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_NULL)
+}
+
+// builtinIsFunction checks whether the argument is a callable function value.
+// This includes closures, built-in functions, and overloaded closures.
+// Used as a primitive constraint: fn |> Function?
+func builtinIsFunction(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	switch args[0].Type {
+	case value.TYPE_FUNCTION, value.TYPE_CLOSURE, value.TYPE_BUILTIN,
+		value.TYPE_PARTIAL_BUILTIN, value.TYPE_OVERLOADED_CLOSURE:
+		return value.Bool(true)
+	default:
+		return value.Bool(false)
+	}
+}
+
+// builtinIsNumber checks whether the argument is an integer or float value.
+// Used as a primitive constraint: 42 |> Number?
+func builtinIsNumber(args ...value.Value) value.Value {
+	if len(args) != 1 {
+		return value.Bool(false)
+	}
+	return value.Bool(args[0].Type == value.TYPE_INT || args[0].Type == value.TYPE_FLOAT)
 }

--- a/tests/primitive_constraint.test.ca
+++ b/tests/primitive_constraint.test.ca
@@ -1,0 +1,71 @@
+// Primitive Constraint Test
+use core.io!;
+use test;
+use core.types;
+
+io.println("# Primitive Constraint Tests");
+
+// Get a null value for testing
+null_val = types.null;
+
+// Helper functions using constraint check syntax
+func is_int(x) = x |> Int? !? { success(_) => true  failure(_) => false };
+func is_float(x) = x |> Float? !? { success(_) => true  failure(_) => false };
+func is_string(x) = x |> String? !? { success(_) => true  failure(_) => false };
+func is_bool(x) = x |> Bool? !? { success(_) => true  failure(_) => false };
+func is_array(x) = x |> Array? !? { success(_) => true  failure(_) => false };
+func is_null(x) = x |> Null? !? { success(_) => true  failure(_) => false };
+func is_function(x) = x |> Function? !? { success(_) => true  failure(_) => false };
+func is_number(x) = x |> Number? !? { success(_) => true  failure(_) => false };
+
+func add(a, b) = a + b;
+
+test.new()
+    |> test.plan(38)
+    // Int?
+    |> test.ok("42 is Int", is_int(42))
+    |> test.ok("-1 is Int", is_int(-1))
+    |> test.ok("0 is Int", is_int(0))
+    |> test.is("3.14 is not Int", is_int(3.14), false)
+    |> test.is("\"hi\" is not Int", is_int("hi"), false)
+    |> test.is("true is not Int", is_int(true), false)
+    |> test.is("null is not Int", is_int(null_val), false)
+    // Float?
+    |> test.ok("3.14 is Float", is_float(3.14))
+    |> test.ok("-1.5 is Float", is_float(-1.5))
+    |> test.is("42 is not Float", is_float(42), false)
+    |> test.is("\"hi\" is not Float", is_float("hi"), false)
+    // String?
+    |> test.ok("\"hello\" is String", is_string("hello"))
+    |> test.ok("\"\" is String", is_string(""))
+    |> test.is("42 is not String", is_string(42), false)
+    |> test.is("true is not String", is_string(true), false)
+    // Bool?
+    |> test.ok("true is Bool", is_bool(true))
+    |> test.ok("false is Bool", is_bool(false))
+    |> test.is("1 is not Bool", is_bool(1), false)
+    |> test.is("\"true\" is not Bool", is_bool("true"), false)
+    // Array?
+    |> test.ok("[1, 2, 3] is Array", is_array([1, 2, 3]))
+    |> test.ok("[] is Array", is_array([]))
+    |> test.is("42 is not Array", is_array(42), false)
+    |> test.is("\"arr\" is not Array", is_array("arr"), false)
+    // Null?
+    |> test.ok("null is Null", is_null(null_val))
+    |> test.is("0 is not Null", is_null(0), false)
+    |> test.is("false is not Null", is_null(false), false)
+    |> test.is("\"\" is not Null", is_null(""), false)
+    // Function?
+    |> test.ok("add is Function", is_function(add))
+    |> test.ok("len is Function", is_function(len))
+    |> test.is("42 is not Function", is_function(42), false)
+    |> test.is("\"fn\" is not Function", is_function("fn"), false)
+    // Number?
+    |> test.ok("42 is Number", is_number(42))
+    |> test.ok("3.14 is Number", is_number(3.14))
+    |> test.ok("-1 is Number", is_number(-1))
+    |> test.ok("-1.5 is Number", is_number(-1.5))
+    |> test.is("\"42\" is not Number", is_number("42"), false)
+    |> test.is("true is not Number", is_number(true), false)
+    |> test.is("null is not Number", is_number(null_val), false)
+    |> test.done();


### PR DESCRIPTION
Issue: gh-120

## Summary

プリミティブ型に対する組み込みconstraint関数を実装しました。`value |> TypeName?` 構文で宣言なしに型チェックができます。

### 実装したプリミティブconstraint

| 制約名 | 説明 |
|--------|------|
| `Int?` | 整数型かどうか |
| `Float?` | 浮動小数点型かどうか |
| `String?` | 文字列型かどうか |
| `Bool?` | 真偽値型かどうか |
| `Array?` | 配列型かどうか |
| `Hash?` | ハッシュ型かどうか |
| `Tuple?` | タプル型かどうか |
| `Null?` | null かどうか |
| `Function?` | 関数型かどうか (closure, builtin, overloaded closure含む) |
| `Number?` | Int または Float かどうか |

## 変更ファイル

- `pkg/vm/vm.go` - VM builtinsリストに10個の型チェック関数を追加、各関数の実装を追加
- `pkg/compiler/compiler.go` - コンパイラのbuiltinシンボルテーブルに型名を登録
- `tests/primitive_constraint.test.ca` - 38ケースのテストを追加（正常系・異常系）

## 使用例

```
42 |> Int?        // success(42)
"hello" |> Int?   // failure("hello")
3.14 |> Number?   // success(3.14)
len |> Function?  // success(len)
```