### PR TITLE
feat(gh-121): implement constraint specification for function arguments and return values

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -91,15 +91,17 @@ func (ht *HeadTailDestructuringStatement) TokenLiteral() string { return ht.Toke
 
 // FunctionDeclaration represents: func name(params) = body;
 // Optionally typed: func name(a: Int, b: Int): Int = body;
+// Constraint on return: func name(a: Positive, b: Positive): Positive = body;
 type FunctionDeclaration struct {
-	Token       token.Token // the FUNC token
-	Name        *Identifier
-	Parameters  []*Identifier
-	Constraints []*Identifier     // constraint for each parameter (nil if none)
-	ParamTypes  []*TypeAnnotation // optional type annotation for each parameter (nil if not annotated)
-	ReturnType  *TypeAnnotation   // optional return type annotation (nil if not annotated)
-	Body        Expression
-	IsEffect    bool // true for func! (side-effect function)
+	Token            token.Token // the FUNC token
+	Name             *Identifier
+	Parameters       []*Identifier
+	Constraints      []*Identifier     // constraint for each parameter (nil if none)
+	ParamTypes       []*TypeAnnotation // optional type annotation for each parameter (nil if not annotated)
+	ReturnType       *TypeAnnotation   // optional return type annotation (nil if not annotated)
+	ReturnConstraint *Identifier       // optional return constraint (nil if not annotated with constraint)
+	Body             Expression
+	IsEffect         bool // true for func! (side-effect function)
 }
 
 func (fd *FunctionDeclaration) statementNode()       {}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -681,14 +681,115 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 
+		// Also enforce type annotations as constraints when a constraint function
+		// with the same name exists (builtin like Int, String, etc. or user-defined).
+		// This allows: func sum(a: Int, b: Int) = a + b; to enforce Int constraint.
+		for i, typeAnnot := range node.ParamTypes {
+			if typeAnnot != nil && node.Constraints[i] == nil {
+				// Only if no explicit constraint already set for this parameter
+				constraintSymbol, ok := c.symbolTable.Resolve(typeAnnot.Name)
+				if ok {
+					hasConstraints = true
+					paramSymbol, _ := c.symbolTable.Resolve(node.Parameters[i].Value)
+
+					// Load parameter value (saved for failure message)
+					c.emit(bytecode.OpGetLocal, paramSymbol.Index)
+
+					// Load constraint function
+					c.loadSymbol(constraintSymbol)
+
+					// Load parameter value for the call
+					c.emit(bytecode.OpGetLocal, paramSymbol.Index)
+
+					// Call constraint(value)
+					c.emit(bytecode.OpCall, 1)
+
+					// Check constraint result - if false, return failure
+					jumpIfTruePos := c.emit(bytecode.OpJumpIfTrue, 9999)
+
+					// Constraint failed - return failure(value)
+					c.emit(bytecode.OpPop) // pop the saved value
+					c.emit(bytecode.OpGetLocal, paramSymbol.Index)
+					c.emit(bytecode.OpWrapFailure)
+					c.emit(bytecode.OpReturn)
+
+					// Constraint passed - continue
+					afterPos := len(c.currentInstructions())
+					c.changeOperand(jumpIfTruePos, afterPos)
+					c.emit(bytecode.OpPop) // pop the saved value
+				}
+			}
+		}
+
 		// Compile function body
 		err := c.Compile(node.Body)
 		if err != nil {
 			return err
 		}
 
+		// Check return constraint if specified (explicit constraint or type annotation)
+		// Determine the effective return constraint name:
+		// 1. Explicit ReturnConstraint (e.g., func add(a, b): Positive = ...)
+		// 2. ReturnType annotation with a resolvable constraint (e.g., func add(a, b): Int = ...)
+		var returnConstraintName string
+		var returnConstraintToken token.Token
+		if node.ReturnConstraint != nil {
+			returnConstraintName = node.ReturnConstraint.Value
+			returnConstraintToken = node.ReturnConstraint.Token
+		} else if node.ReturnType != nil {
+			// Check if the return type name resolves to a constraint function
+			if _, ok := c.symbolTable.Resolve(node.ReturnType.Name); ok {
+				returnConstraintName = node.ReturnType.Name
+				returnConstraintToken = node.ReturnType.Token
+			}
+		}
+
+		hasReturnConstraint := returnConstraintName != ""
+		if hasReturnConstraint {
+			hasConstraints = true
+
+			// Stack has: [return_value]
+			// We need to: dup value, call constraint, check result
+
+			// Store return value in a temporary local
+			tmpSymbol := c.symbolTable.Define("__return_tmp__")
+			c.emit(bytecode.OpSetLocal, tmpSymbol.Index)
+
+			// Load constraint function (from outer scope)
+			constraintSymbol, ok := c.symbolTable.Resolve(returnConstraintName)
+			if !ok {
+				msg := fmt.Sprintf("undefined return constraint '%s'", returnConstraintName)
+				candidates := c.getAllDefinedNames()
+				if similar := findSimilarName(returnConstraintName, candidates, 2); similar != "" {
+					msg += fmt.Sprintf(" (did you mean '%s'?)", similar)
+				}
+				return c.newCompileError(returnConstraintToken, msg)
+			}
+			c.loadSymbol(constraintSymbol)
+
+			// Load return value for the call
+			c.emit(bytecode.OpGetLocal, tmpSymbol.Index)
+
+			// Call constraint(return_value)
+			c.emit(bytecode.OpCall, 1)
+
+			// Check constraint result - if true, continue to wrap in success
+			// OpJumpIfTrue pops the condition value from the stack
+			jumpIfTruePos := c.emit(bytecode.OpJumpIfTrue, 9999)
+
+			// Constraint failed - return failure(value)
+			c.emit(bytecode.OpGetLocal, tmpSymbol.Index)
+			c.emit(bytecode.OpWrapFailure)
+			c.emit(bytecode.OpReturn)
+
+			// Constraint passed - push the original value for wrapping in success
+			afterPos := len(c.currentInstructions())
+			c.changeOperand(jumpIfTruePos, afterPos)
+			c.emit(bytecode.OpGetLocal, tmpSymbol.Index)
+		}
+
 		// For effect functions (func!), wrap return value in success
-		// Also wrap if function has parameter constraints (makes it return success/failure)
+		// Also wrap if function has parameter constraints or return constraint (makes it return success/failure)
 		if node.IsEffect || hasConstraints {
 			c.emit(bytecode.OpWrapSuccess)
 		}

--- a/pkg/optimizer/constant_fold.go
+++ b/pkg/optimizer/constant_fold.go
@@ -100,12 +100,15 @@ func foldAssignmentStatement(as *ast.AssignmentStatement) *ast.AssignmentStateme
 
 func foldFunctionDeclaration(fd *ast.FunctionDeclaration) *ast.FunctionDeclaration {
 	return &ast.FunctionDeclaration{
-		Token:       fd.Token,
-		Name:        fd.Name,
-		Parameters:  fd.Parameters,
-		Constraints: fd.Constraints,
-		Body:        foldNode(fd.Body).(ast.Expression),
-		IsEffect:    fd.IsEffect,
+		Token:            fd.Token,
+		Name:             fd.Name,
+		Parameters:       fd.Parameters,
+		Constraints:      fd.Constraints,
+		ParamTypes:       fd.ParamTypes,
+		ReturnType:       fd.ReturnType,
+		ReturnConstraint: fd.ReturnConstraint,
+		Body:             foldNode(fd.Body).(ast.Expression),
+		IsEffect:         fd.IsEffect,
 	}
 }
 

--- a/pkg/optimizer/cse.go
+++ b/pkg/optimizer/cse.go
@@ -80,12 +80,15 @@ func (o *CSEOptimizer) optimize(node ast.Node) ast.Node {
 		}
 	case *ast.FunctionDeclaration:
 		return &ast.FunctionDeclaration{
-			Token:       n.Token,
-			Name:        n.Name,
-			Parameters:  n.Parameters,
-			Constraints: n.Constraints,
-			Body:        o.optimizeExpr(n.Body),
-			IsEffect:    n.IsEffect,
+			Token:            n.Token,
+			Name:             n.Name,
+			Parameters:       n.Parameters,
+			Constraints:      n.Constraints,
+			ParamTypes:       n.ParamTypes,
+			ReturnType:       n.ReturnType,
+			ReturnConstraint: n.ReturnConstraint,
+			Body:             o.optimizeExpr(n.Body),
+			IsEffect:         n.IsEffect,
 		}
 	case *ast.ConstraintDeclaration:
 		return &ast.ConstraintDeclaration{

--- a/pkg/optimizer/dead_code.go
+++ b/pkg/optimizer/dead_code.go
@@ -96,12 +96,15 @@ func eliminateDeadCodeAssignmentStatement(as *ast.AssignmentStatement) *ast.Assi
 
 func eliminateDeadCodeFunctionDeclaration(fd *ast.FunctionDeclaration) *ast.FunctionDeclaration {
 	return &ast.FunctionDeclaration{
-		Token:       fd.Token,
-		Name:        fd.Name,
-		Parameters:  fd.Parameters,
-		Constraints: fd.Constraints,
-		Body:        eliminateDeadCode(fd.Body).(ast.Expression),
-		IsEffect:    fd.IsEffect,
+		Token:            fd.Token,
+		Name:             fd.Name,
+		Parameters:       fd.Parameters,
+		Constraints:      fd.Constraints,
+		ParamTypes:       fd.ParamTypes,
+		ReturnType:       fd.ReturnType,
+		ReturnConstraint: fd.ReturnConstraint,
+		Body:             eliminateDeadCode(fd.Body).(ast.Expression),
+		IsEffect:         fd.IsEffect,
 	}
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -629,21 +629,24 @@ func (p *Parser) parseFunctionDeclaration() *ast.FunctionDeclaration {
 
 	stmt.Parameters, stmt.Constraints, stmt.ParamTypes = p.parseFunctionParametersWithConstraints()
 
-	// Optional return type annotation: ): ReturnType =
+	// Optional return type/constraint annotation: ): ReturnType =
 	// Syntax: func add(a: Int, b: Int): Int = a + b
+	// With constraint: func add(a: Positive, b: Positive): Positive = a + b
 	if p.peekTokenIs(token.COLON) {
 		p.nextToken() // consume ':'
-		p.nextToken() // get return type name
+		p.nextToken() // get return type/constraint name
 		retTypeTok := p.curToken
 		retTypeName := retTypeTok.Literal
-		if types.IsBuiltinTypeName(retTypeName) {
+
+		// If it's a known built-in type name and NOT followed by '?', treat as type annotation.
+		if types.IsBuiltinTypeName(retTypeName) && !p.peekTokenIs(token.QUESTION) {
 			stmt.ReturnType = &ast.TypeAnnotation{Token: retTypeTok, Name: retTypeName}
 		} else {
-			p.errors = append(p.errors, p.formatErrorWithContext(
-				retTypeTok.Line, retTypeTok.Column,
-				fmt.Sprintf("unknown return type %q; expected a built-in type (Int, Float, String, Bool, Null, Array, Hash, Tuple, Func, Regex, Any, Success, Failure)", retTypeName),
-			))
-			return nil
+			// Otherwise treat as a return constraint (user-defined constraint name)
+			stmt.ReturnConstraint = &ast.Identifier{Token: retTypeTok, Value: retTypeName}
+			if p.peekTokenIs(token.QUESTION) {
+				p.nextToken() // consume '?'
+			}
 		}
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1912,24 +1912,31 @@ func TestFunctionDeclarationWithEffectHandle(t *testing.T) {
 	}
 }
 
-func TestFunctionDeclarationWithUnknownReturnType(t *testing.T) {
+func TestFunctionDeclarationWithReturnConstraint(t *testing.T) {
+	// Non-builtin return type names are now parsed as return constraints
 	input := `func add(a, b): UnknownType = a + b;`
 	l := lexer.New(input)
 	p := New(l)
-	p.ParseProgram()
-	errors := p.Errors()
-	if len(errors) == 0 {
-		t.Fatal("expected error for unknown return type")
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(program.Statements))
 	}
-	found := false
-	for _, e := range errors {
-		if containsString(e, "unknown return type") {
-			found = true
-			break
-		}
+
+	stmt, ok := program.Statements[0].(*ast.FunctionDeclaration)
+	if !ok {
+		t.Fatalf("expected *ast.FunctionDeclaration, got %T", program.Statements[0])
 	}
-	if !found {
-		t.Errorf("expected error about unknown return type, got: %v", errors)
+
+	if stmt.ReturnConstraint == nil {
+		t.Fatal("expected return constraint to be set")
+	}
+	if stmt.ReturnConstraint.Value != "UnknownType" {
+		t.Errorf("expected return constraint 'UnknownType', got %q", stmt.ReturnConstraint.Value)
+	}
+	if stmt.ReturnType != nil {
+		t.Error("expected ReturnType to be nil when constraint is set")
 	}
 }
 

--- a/tests/function_constraint.test.ca
+++ b/tests/function_constraint.test.ca
@@ -1,0 +1,88 @@
+// Function Argument and Return Constraint Test
+use core.io!;
+use test;
+
+io.println("# Function Constraint Tests");
+
+// === Define Constraints ===
+constraint Positive(x) = x > 0;
+constraint NonNeg(x) = x >= 0;
+constraint Even(n) = n % 2 == 0;
+constraint NonEmpty(s) = len(s) > 0;
+
+// === Functions with parameter constraints ===
+func add_positive(a: Positive, b: Positive) = a + b;
+func double_even(n: Even) = n * 2;
+
+// === Functions with parameter AND return constraints ===
+func safe_add(a: Positive, b: Positive): Positive = a + b;
+func safe_sub(a: NonNeg, b: NonNeg): NonNeg = a - b;
+
+// === Functions with return constraint only ===
+func make_positive(x): Positive = x * x + 1;
+func make_negative(x): Positive = 0 - x;
+
+// === Functions with constraints using primitives ===
+constraint IsInt(n) = n |> Int? !? { success(_) => true  failure(_) => false };
+func typed_add(a: IsInt, b: IsInt): IsInt = a + b;
+
+// === Functions with built-in type annotations as constraints ===
+// Type annotations (Int, String, etc.) are enforced as constraints at runtime
+func int_add(a: Int, b: Int): Int = a + b;
+func str_len(s: String): Int = len(s);
+func to_array(x): Array = [x];
+
+// === User-defined constraint shadowing built-in type name ===
+// User can redefine constraint with same name as built-in type
+constraint MyInt(n) = n |> Int? !? { success(_) => true  failure(_) => false };
+func my_int_add(a: MyInt, b: MyInt): MyInt = a + b;
+
+test.new()
+    |> test.plan(29)
+    // Parameter constraints - passing
+    |> test.is("add_positive(3, 5)", add_positive(3, 5) !? { success(v) => v  failure(_) => "fail" }, 8)
+    |> test.is("double_even(4)", double_even(4) !? { success(v) => v  failure(_) => "fail" }, 8)
+    // Parameter constraints - failing
+    |> test.is("add_positive(-1, 5) fails", add_positive(-1, 5) !? { success(_) => "pass"  failure(_) => "fail" }, "fail")
+    |> test.is("double_even(3) fails", double_even(3) !? { success(_) => "pass"  failure(_) => "fail" }, "fail")
+    // Return constraint - passing
+    |> test.is("safe_add(3, 5) passes return", safe_add(3, 5) !? { success(v) => v  failure(_) => "fail" }, 8)
+    |> test.is("make_positive(3) passes return", make_positive(3) !? { success(v) => v  failure(_) => "fail" }, 10)
+    // Return constraint - failing
+    |> test.is("safe_sub(3, 5) fails return", safe_sub(3, 5) !? { success(_) => "pass"  failure(v) => v }, -2)
+    |> test.is("make_negative(5) fails return", make_negative(5) !? { success(_) => "pass"  failure(v) => v }, -5)
+    // Both param and return constraint passing
+    |> test.is("safe_add(1, 2) both pass", safe_add(1, 2) !? { success(v) => v  failure(_) => "fail" }, 3)
+    |> test.is("safe_sub(10, 3) both pass", safe_sub(10, 3) !? { success(v) => v  failure(_) => "fail" }, 7)
+    // Both param and return constraint - param fails
+    |> test.is("safe_add(-1, 2) param fails", safe_add(-1, 2) !? { success(_) => "pass"  failure(_) => "fail" }, "fail")
+    // Both param and return constraint - return fails
+    |> test.is("safe_sub(2, 5) return fails", safe_sub(2, 5) !? { success(_) => "pass"  failure(v) => v }, -3)
+    // Primitive constraint as parameter and return
+    |> test.is("typed_add(3, 5) passes", typed_add(3, 5) !? { success(v) => v  failure(_) => "fail" }, 8)
+    // Return constraint only functions
+    |> test.is("make_positive(0) passes", make_positive(0) !? { success(v) => v  failure(_) => "fail" }, 1)
+    |> test.is("make_negative(3) fails", make_negative(3) !? { success(_) => "pass"  failure(v) => v }, -3)
+    // Constraint composition in function
+    |> test.is("safe_add(10, 20) = 30", safe_add(10, 20) !? { success(v) => v  failure(_) => "fail" }, 30)
+    |> test.is("safe_sub(0, 0) = 0", safe_sub(0, 0) !? { success(v) => v  failure(_) => "fail" }, 0)
+    |> test.is("safe_sub(5, 5) = 0", safe_sub(5, 5) !? { success(v) => v  failure(_) => "fail" }, 0)
+    // Built-in type annotation as constraint - passing
+    |> test.is("int_add(3, 5) passes", int_add(3, 5) !? { success(v) => v  failure(_) => "fail" }, 8)
+    |> test.is("str_len(\"hello\") passes", str_len("hello") !? { success(v) => v  failure(_) => "fail" }, 5)
+    |> test.is("to_array(42) passes", to_array(42) !? { success(v) => v  failure(_) => "fail" }, [42])
+    // Built-in type annotation as constraint - failing
+    |> test.is("int_add(\"a\", 5) fails", int_add("a", 5) !? { success(_) => "pass"  failure(_) => "fail" }, "fail")
+    |> test.is("str_len(42) fails", str_len(42) !? { success(_) => "pass"  failure(_) => "fail" }, "fail")
+    // Built-in return type constraint - failing
+    |> test.is("str_len(\"hi\") return Int", str_len("hi") !? { success(v) => v  failure(_) => "fail" }, 2)
+    // User-defined constraint with type check
+    |> test.is("my_int_add(3, 5) passes", my_int_add(3, 5) !? { success(v) => v  failure(_) => "fail" }, 8)
+    |> test.is("my_int_add(\"a\", 5) fails", my_int_add("a", 5) !? { success(_) => "pass"  failure(_) => "fail" }, "fail")
+    // int_add with both ints
+    |> test.is("int_add(10, 20) = 30", int_add(10, 20) !? { success(v) => v  failure(_) => "fail" }, 30)
+    // int_add return constraint check
+    |> test.is("int_add(1, 2) return check", int_add(1, 2) !? { success(v) => v  failure(_) => "fail" }, 3)
+    // str_len with empty string
+    |> test.is("str_len(\"\") = 0", str_len("") !? { success(v) => v  failure(_) => "fail" }, 0)
+    |> test.done();


### PR DESCRIPTION
## Summary

- Add `ReturnConstraint` field to `FunctionDeclaration` AST node for constraint annotations on return values
- Parser now recognizes non-builtin type names as constraint annotations (e.g., `func sum(a: Positive): Positive = ...`)
- Compiler generates constraint check bytecode for both parameter and return value constraints
- **Fix critical bug**: optimizer passes (constant folding, dead code elimination, CSE) were dropping `ParamTypes`, `ReturnType`, and `ReturnConstraint` fields when reconstructing `FunctionDeclaration` nodes, causing all constraint enforcement to silently disappear after optimization

## Usage Examples

```calcium
constraint Positive(x) = x > 0;
func safe_add(a: Positive, b: Positive): Positive = a + b;
safe_add(3, 5)   // success(8)
safe_add(-1, 5)  // failure(-1)

// Built-in type constraints
func int_add(a: Int, b: Int): Int = a + b;
int_add(3, 5)    // success(8)
int_add("a", 5)  // failure("a")
```

## Test plan

- [x] All 29 function constraint tests pass (previously 11 failing)
- [x] All 31 basic constraint tests pass
- [x] All 38 primitive constraint tests pass
- [x] Full `go test ./...` passes with no regressions
- [x] gh-121 issue example (`constraint Int(n) = regex.matches(...)` + `func sum(a: Int, b: Int): Int`) verified working

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)